### PR TITLE
Link to new firmata lib for Ruby.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ Most of the time you will be interacting with arduino with a client library on t
   * [https://github.com/amimoto/perl-firmata]
   * [https://github.com/rcaputo/rx-firmata]
 * ruby 
-  * [https://github.com/patcoll/ruby-firmata]
+  * [https://github.com/hardbap/firmata]
   * [https://github.com/PlasticLizard/rufinol]
   * [http://funnel.cc]
 * clojure


### PR DESCRIPTION
ruby-firmata is no longer active nor is it complete. 
Linked to the firmata library I built in ruby which is active and working.
