### PR TITLE
fixes file path issue for windows in setFirmwareNameAndVersion

### DIFF
--- a/Firmata.cpp
+++ b/Firmata.cpp
@@ -144,7 +144,7 @@ void FirmataClass::setFirmwareNameAndVersion(const char *name, byte major, byte 
     firmwareVersionCount = extension - firmwareName + 2;
   }
     
-  // in case anyone every calls setFirmwareNameAndVersion more than once
+  // in case anyone calls setFirmwareNameAndVersion more than once
   free(firmwareVersionVector);
 
   firmwareVersionVector = (byte *) malloc(firmwareVersionCount);


### PR DESCRIPTION
This is a fix for [issue #4](https://github.com/firmata/arduino/issues/4). It's sorta hacky but it's the best I could come up with. There was also a request (and proposal) to add a new method to manually set the firmware name. That could be added as well via a separate request if people think that functionality is important.

UPDATE: 8/4/13
Updated per recommendation from @kisoft in comment for [issue #4]. Tested on OS X and Windows 7. Should be good to go.
