### PR TITLE
Call flush on system reset

### DIFF
--- a/Firmata.cpp
+++ b/Firmata.cpp
@@ -49,7 +49,7 @@ void FirmataClass::endSysex(void)
 FirmataClass::FirmataClass()
 {
   firmwareVersionCount = 0;
-  systemReset();
+  init();
 }
 
 //******************************************************************************
@@ -400,10 +400,8 @@ void FirmataClass::detach(byte command)
 //* Private Methods
 //******************************************************************************
 
-
-
-// resets the system state upon a SYSTEM_RESET message from the host software
-void FirmataClass::systemReset(void)
+// initialize to a known state
+void FirmataClass::init(void)
 {
   byte i;
 
@@ -411,20 +409,24 @@ void FirmataClass::systemReset(void)
   executeMultiByteCommand = 0; // execute this after getting multi-byte data
   multiByteChannel = 0; // channel data for multiByteCommands
 
-
   for(i=0; i<MAX_DATA_BYTES; i++) {
     storedInputData[i] = 0;
   }
 
   parsingSysex = false;
-  sysexBytesRead = 0;
+  sysexBytesRead = 0;  
+}
+
+// resets the system state upon a SYSTEM_RESET message from the host software
+void FirmataClass::systemReset(void)
+{
+  init();
 
   if(currentSystemResetCallback)
     (*currentSystemResetCallback)();
 
-  //flush(); //TODO uncomment when Firmata is a subclass of HardwareSerial
+  FirmataSerial->flush();
 }
-
 
 
 // =============================================================================

--- a/Firmata.h
+++ b/Firmata.h
@@ -140,6 +140,7 @@ private:
     sysexCallbackFunction currentSysexCallback;
 
 /* private methods ------------------------------ */
+    void init(void);
     void processSysexMessage(void);
     void systemReset(void);
     void pin13strobe(int count, int onInterval, int offInterval);


### PR DESCRIPTION
I added an init method to be called by the constructor rather than calling systemReset in the constructor. This was so I could flush the stream when systemReset is called. This should help ensure stability for Firmata clients that rely on a serial proxy.

Anyone have any objections to this update or other suggestions?
