### PR TITLE
Fixed issue #36 (setFirmwareVersion leaks memory)

### DIFF
--- a/Firmata.cpp
+++ b/Firmata.cpp
@@ -49,6 +49,7 @@ void FirmataClass::endSysex(void)
 FirmataClass::FirmataClass()
 {
   firmwareVersionCount = 0;
+  firmwareVersionVector = 0;
   systemReset();
 }
 
@@ -126,6 +127,9 @@ void FirmataClass::setFirmwareNameAndVersion(const char *name, byte major, byte 
     firmwareVersionCount = strlen(name) + 2;
     filename = name;
   }
+
+  free(firmwareVersionVector);
+
   firmwareVersionVector = (byte *) malloc(firmwareVersionCount);
   firmwareVersionVector[firmwareVersionCount] = 0;
   firmwareVersionVector[0] = major;
@@ -136,6 +140,13 @@ void FirmataClass::setFirmwareNameAndVersion(const char *name, byte major, byte 
   //             (char)major, (char)minor, firmwareVersionVector);
 }
 
+void FirmataClass::unsetFirmwareVersion()
+{
+  firmwareVersionCount = 0;
+  free(firmwareVersionVector); 
+  firmwareVersionVector = 0;
+}
+ 
 //------------------------------------------------------------------------------
 // Serial Receive Handling
 
@@ -179,7 +190,7 @@ void FirmataClass::processInput(void)
   int command;
     
   // TODO make sure it handles -1 properly
-
+  
   if (parsingSysex) {
     if(inputData == END_SYSEX) {
       //stop sysex byte      

--- a/Firmata.h
+++ b/Firmata.h
@@ -98,6 +98,7 @@ public:
     void printFirmwareVersion(void);
   //void setFirmwareVersion(byte major, byte minor);  // see macro below
     void setFirmwareNameAndVersion(const char *name, byte major, byte minor);
+    void unsetFirmwareVersion();
 /* serial receive handling */
     int available(void);
     void processInput(void);


### PR DESCRIPTION
This pull request includes a new method (`unsetFirmwareVersion()`) on `FirmataClass`. This exists only to ensure that the unit test covering the memory leak fix is independent of other unit tests.

An alternative approach, whereby a new FirmataClass instance was created within the test, failed due to the amount of SRAM this required (reporting of unit test results via the Serial port got corrupted, presumably due to stack/heap collision).
