### PR TITLE
For Review and Discussion: SHIFT IN/OUT feature class

### DIFF
--- a/examples/ConfigurableFirmata/ConfigurableFirmata.ino
+++ b/examples/ConfigurableFirmata/ConfigurableFirmata.ino
@@ -64,6 +64,9 @@ OneWireFirmata oneWire;
 #include <utility/StepperFirmata.h>
 StepperFirmata stepper;
 
+#include <utility/ShiftFirmata.h>
+ShiftFirmata shift;
+
 #include <utility/FirmataExt.h>
 FirmataExt firmataExt;
 
@@ -148,6 +151,9 @@ void setup()
 #ifdef StepperFirmata_h
   firmataExt.addFeature(stepper);
 #endif
+#ifdef ShiftFirmata_h
+  firmataExt.addFeature(shift);
+#endif  
 #ifdef FirmataReporting_h
   firmataExt.addFeature(reporting);
 #endif

--- a/utility/I2CFirmata.h
+++ b/utility/I2CFirmata.h
@@ -21,7 +21,6 @@
 #include <utility/FirmataFeature.h>
 #include <FirmataReporting.h>
 
-// move the following defines to Firmata.h?
 #define I2C_WRITE B00000000
 #define I2C_READ B00001000
 #define I2C_READ_CONTINUOUSLY B00010000

--- a/utility/ShiftFirmata.cpp
+++ b/utility/ShiftFirmata.cpp
@@ -3,7 +3,7 @@
   Copyright (C) 2006-2008 Hans-Christoph Steiner.  All rights reserved.
   Copyright (C) 2010-2011 Paul Stoffregen.  All rights reserved.
   Copyright (C) 2009 Shigeru Kobayashi.  All rights reserved.
-  Copyright (C) 2009-2011 Jeff Hoefs.  All rights reserved.
+  Copyright (C) 2009-2013 Jeff Hoefs.  All rights reserved.
   Copyright (C) 2013 Norbert Truchsess. All rights reserved.
 
   This library is free software; you can redistribute it and/or

--- a/utility/ShiftFirmata.cpp
+++ b/utility/ShiftFirmata.cpp
@@ -1,0 +1,116 @@
+/*
+  ShiftFirmata.cpp - Firmata library
+  Copyright (C) 2006-2008 Hans-Christoph Steiner.  All rights reserved.
+  Copyright (C) 2010-2011 Paul Stoffregen.  All rights reserved.
+  Copyright (C) 2009 Shigeru Kobayashi.  All rights reserved.
+  Copyright (C) 2009-2011 Jeff Hoefs.  All rights reserved.
+  Copyright (C) 2013 Norbert Truchsess. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  See file LICENSE.txt for further informations on licensing terms.
+*/
+
+#include <Firmata.h>
+#include <ShiftFirmata.h>
+#include <Encoder7Bit.h>
+
+boolean ShiftFirmata::handlePinMode(byte pin, int mode)
+{
+  if (IS_PIN_DIGITAL(pin)) {
+    if (mode == SHIFT) {
+      // pin modes for data, clock and latch pins need to be set separately
+      return true;
+    }
+  }
+  return false;
+}
+
+void ShiftFirmata::handleCapability(byte pin)
+{
+  if (IS_PIN_DIGITAL(pin)) {
+    Firmata.write(SHIFT);
+    Firmata.write(8); //8-bit resolution. Can send and receive multiple bytes.
+  }
+}
+
+boolean ShiftFirmata::handleSysex(byte command, byte argc, byte* argv)
+{
+  if(command == SHIFT_DATA) {
+    byte shiftCommand, dataPin, clockPin, latchPin, bitOrder;
+    byte shiftInData, shiftOutData;
+    int numBytes;
+
+    numBytes = 0;
+
+    shiftCommand = argv[0];
+    dataPin = argv[1];
+    clockPin = argv[2];
+    latchPin = argv[3];
+    bitOrder = argv[4];
+
+    // set only the data pin to SHIFT
+    if (Firmata.getPinMode(dataPin != SHIFT)) {
+      Firmata.setPinMode(dataPin, SHIFT);
+    }
+
+    if (shiftCommand == SHIFT_OUT) {
+      numBytes = num7BitOutbytes(argc - 5); // data starts after bitOrder (argv[4])
+      argv += 5;
+      Encoder7Bit.readBinary(numBytes, argv, argv); // decode in place
+
+      for (int i = 0; i < numBytes; i++) {
+        shiftOutData = argv[i];
+
+        digitalWrite(latchPin, LOW);
+        shiftOut(dataPin, clockPin, bitOrder, shiftOutData);
+        digitalWrite(latchPin, HIGH);
+      }
+
+    } else if (shiftCommand == SHIFT_IN) {
+      numBytes = argv[5];
+      Firmata.write(START_SYSEX);
+      Firmata.write(SHIFT_DATA);
+      Firmata.write(SHIFT_IN_REPLY);
+      Firmata.write(dataPin);
+      Encoder7Bit.startBinaryWrite();
+      for (int i = 0; i < numBytes; i++) {
+        digitalWrite(latchPin, LOW); // load bits
+        digitalWrite(latchPin, HIGH);
+
+        shiftInData = shift_In(dataPin, clockPin, bitOrder);
+        Encoder7Bit.writeBinary(shiftInData);
+      }
+      Encoder7Bit.endBinaryWrite();
+      Firmata.write(END_SYSEX);
+    }
+    return true;
+  }
+  return false;
+}
+
+// The built-in arduino shiftIn function doesn't work so we need our own.
+byte ShiftFirmata::shift_In(byte dataPin, byte clockPin, byte bitOrder)
+{
+  byte value = 0;
+  byte i;
+
+  for (i = 0; i < 8; i++) {
+    if (bitOrder == LSBFIRST)
+      value |= digitalRead(dataPin) << i;
+    else
+      value |= digitalRead(dataPin) << (7 - i);
+
+    digitalWrite(clockPin, HIGH);
+    digitalWrite(clockPin, LOW);
+  }
+  return value;
+}
+
+void ShiftFirmata::reset()
+{
+  // to do: any necessary cleanup
+}

--- a/utility/ShiftFirmata.cpp
+++ b/utility/ShiftFirmata.cpp
@@ -62,13 +62,12 @@ boolean ShiftFirmata::handleSysex(byte command, byte argc, byte* argv)
       argv += 5;
       Encoder7Bit.readBinary(numBytes, argv, argv); // decode in place
 
+      digitalWrite(latchPin, LOW);
       for (int i = 0; i < numBytes; i++) {
         shiftOutData = argv[i];
-
-        digitalWrite(latchPin, LOW);
         shiftOut(dataPin, clockPin, bitOrder, shiftOutData);
-        digitalWrite(latchPin, HIGH);
       }
+      digitalWrite(latchPin, HIGH);
 
     } else if (shiftCommand == SHIFT_IN) {
       numBytes = argv[5];

--- a/utility/ShiftFirmata.h
+++ b/utility/ShiftFirmata.h
@@ -27,7 +27,6 @@
 class ShiftFirmata:public FirmataFeature
 {
 public:
-  //ShiftFirmata();
   boolean handlePinMode(byte pin, int mode);
   void handleCapability(byte pin);
   boolean handleSysex(byte command, byte argc, byte* argv);

--- a/utility/ShiftFirmata.h
+++ b/utility/ShiftFirmata.h
@@ -1,0 +1,40 @@
+/*
+  ShiftFirmata.h - Firmata library
+  Copyright (C) 2006-2008 Hans-Christoph Steiner.  All rights reserved.
+  Copyright (C) 2010-2011 Paul Stoffregen.  All rights reserved.
+  Copyright (C) 2009 Shigeru Kobayashi.  All rights reserved.
+  Copyright (C) 2009-2013 Jeff Hoefs.  All rights reserved.
+  Copyright (C) 2013 Norbert Truchsess. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  See file LICENSE.txt for further informations on licensing terms.
+*/
+
+#ifndef ShiftFirmata_h
+#define ShiftFirmata_h
+
+#include <Firmata.h>
+#include <utility/FirmataFeature.h>
+
+#define SHIFT_OUT 1
+#define SHIFT_IN 2
+#define SHIFT_IN_REPLY 3
+
+class ShiftFirmata:public FirmataFeature
+{
+public:
+  //ShiftFirmata();
+  boolean handlePinMode(byte pin, int mode);
+  void handleCapability(byte pin);
+  boolean handleSysex(byte command, byte argc, byte* argv);
+  void reset();
+
+private:
+  byte shift_In(byte dataPin, byte clockPin, byte bitOrder);
+};
+
+#endif


### PR DESCRIPTION
UPDATE (6/16/13): Removed latch pins. Will also submit a separate pull request with a shift-config implementation.

I've added a shift in/out feature class. There are a few different ways to approach shift in/out. One approach would be to have a SHIFT_CONFIG to set up the pins for each shift registor, sensor, etc. However, that would require an array of structs to track the pin sets.

I took a different method based on the 1st proposal here: http://firmata.org/wiki/Proposals#ShiftIn.2FOut_Proposal, but with some additions. This approach requires the user to specify all 3 pins (data, clock and latch) each time they want to send a shift-in or shift-out request. Here's the protocol I implemented:

```
// shift out
0  START_SYSEX
1  SHIFT_DATA         (0x75)
2  SHIFT_OUT           (0x01)
3  dataPin
4  clockPin
5  bitOrder (MSBFIRST or LSBFIRST)
n ...      (shift out data)
n+1 END_SYSEX

// shift in (for client application to request shift-in data from microcontroller)
0  START_SYSEX
1  SHIFT_DATA          (0x75)
2  SHIFT_IN                (0x02)
3  dataPin
4  clockPin
5  bitOrder (MSBFIRST or LSBFIRST)
6  numBytes               (number of bytes to shift in. Default to 1)
7 END_SYSEX

// shift in reply (for sending shift-in data to client application)
0  START_SYSEX
1  SHIFT_DATA           (0x75)
2  SHIFT_IN_REPLY    (0x03)
3  dataPin  (so you know which data pin the reply corresponds to)
n ...      (shift in data)
n+1 END_SYSEX
```

However, note that this approach requires the user to set-up the pin modes first. It could alternatively be possible to set them on the 1st call and then check but that introduces another conditional for each call.

My test circuit consists of 2 daisy-chained 74HC595 wired to 16 LEDs and a 74LS165 wired to a block of 8 dip switches (pull-up).

Here's an example client implementation (in JavaScript):

```
/***************** setup pins in client application ****************/
arduino.setDigitalPinMode(4, Pin.DOUT);
arduino.setDigitalPinMode(5, Pin.DOUT);
arduino.setDigitalPinMode(6, Pin.DOUT);

arduino.setDigitalPinMode(11, Pin.DIN);
arduino.setDigitalPinMode(8, Pin.DOUT);
arduino.setDigitalPinMode(12, Pin.DOUT);


/******************* methods in client library **********************/
sendShiftOut: function (dataPin, clockPin, bitOrder, value) {
    var shiftOut = []
        len;

    shiftOut[0] = START_SYSEX;
    shiftOut[1] = SHIFT_DATA; // 0x75
    shiftOut[2] = SHIFT_OUT;  // 0x01
    shiftOut[3] = dataPin.number;
    shiftOut[4] = clockPin.number;
    shiftOut[5] = bitOrder || MSBFIRST;

    // split the value into multiple bytes
    this.encodeMultiByteValue(value);

    len = Encoder7Bit.binaryData.length;
    for (var i = 0; i < len; i++) {
        shiftOut.push(Encoder7Bit.binaryData[i]);
    }
    shiftOut.push(END_SYSEX);

    this.send(shiftOut);
},

sendShiftIn: function (dataPin, clockPin, bitOrder, numBytes) {
    var shiftIn = [];

    shiftIn[0] = START_SYSEX;
    shiftIn[1] = SHIFT_DATA;  // 0x75
    shiftIn[2] = SHIFT_IN;       // 0x02
    shiftIn[3] = dataPin.number;
    shiftIn[4] = clockPin.number;
    shiftIn[5] = bitOrder || MSBFIRST;
    shiftIn[6] = numBytes || 1;
    shiftIn[7] = END_SYSEX;

    this.send(shiftIn);
},

/* example sending shift in request: */
var numBytes = 1;
// toggle latch (only required for hardware that uses a latch)
latchPin.value = Pin.LOW;
latchPin.value = Pin.HIGH;
arduino.sendShiftIn(dataPin, clickPin, MSBFIRST, numBytes);

// Testing shift-in reply. Called when SHIFT_IN_REPLY command is received.
processShiftData: function (msg) {
    var len = msg.length;
    var data = msg.slice(3);
    // decode to array of 8-bit values
    var numBytes = Encoder7Bit.num7BitOutbytes(len - 3);
    var value = Encoder7Bit.readBinary(numBytes, data);
    console.log(value); // array of bytes
}
```
