### PR TITLE
Update to OneWire Feature-class

### DIFF
--- a/Firmata.h
+++ b/Firmata.h
@@ -20,7 +20,7 @@
  * software can test whether it will be compatible with the currently
  * installed firmware. */
 #define FIRMATA_MAJOR_VERSION   2 // for non-compatible changes
-#define FIRMATA_MINOR_VERSION   4 // for backwards compatible changes
+#define FIRMATA_MINOR_VERSION   5 // for backwards compatible changes
 #define FIRMATA_BUGFIX_VERSION  0 // for bugfix releases
 
 #define MAX_DATA_BYTES 64 // max number of data bytes in non-Sysex messages

--- a/utility/OneWireFirmata.cpp
+++ b/utility/OneWireFirmata.cpp
@@ -100,6 +100,7 @@ boolean OneWireFirmata::handleSysex(byte command, byte argc, byte* argv)
             if (subcommand & ONEWIRE_WITHDATA_REQUEST_BITS) {
               int numBytes=num7BitOutbytes(argc-2);
               int numReadBytes=0;
+              int correlationId;
               argv+=2;
               Encoder7Bit.readBinary(numBytes,argv,argv); //decode inplace
 
@@ -114,10 +115,12 @@ boolean OneWireFirmata::handleSysex(byte command, byte argc, byte* argv)
               }
 
               if (subcommand & ONEWIRE_READ_REQUEST_BIT) {
-                if (numBytes<2) break;
+                if (numBytes<4) break;
                 numReadBytes = *((int*)argv);
                 argv+=2;
-                numBytes-=2;
+                correlationId = *((int*)argv);
+                argv+=2;
+                numBytes-=4;
               }
 
               if (subcommand & ONEWIRE_DELAY_REQUEST_BIT) {
@@ -139,9 +142,8 @@ boolean OneWireFirmata::handleSysex(byte command, byte argc, byte* argv)
                 Firmata.write(ONEWIRE_READ_REPLY);
                 Firmata.write(pin);
                 Encoder7Bit.startBinaryWrite();
-                for (int i=0;i<8;i++) {
-                  Encoder7Bit.writeBinary(info->addr[i]);
-                }
+                Encoder7Bit.writeBinary(correlationId&0xFF);
+                Encoder7Bit.writeBinary((correlationId>>8)&0xFF);
                 for (int i=0;i<numReadBytes;i++) {
                   Encoder7Bit.writeBinary(device->read());
                 }


### PR DESCRIPTION
I did update the proposal for 1-Wire (see http://www.firmata.org/wiki/Proposals#OneWire_Proposal). When issuing a OneWire Command-request that requests a number of bytes to be read the request contains a correlationid that is sent back to the client in the resulting OneWire Read reply message. The older way did send the 1-wire-device-address, which can be ambigous when having sent multiple read-requests to e.g. read different memory-locations from an eeprom.
This pull-requests contains the updated OneWire-feature class. In addition it pulls the Firmata-version to 2.5 so client-implementations to signal the change.

The perl-firmata client implementation on https://github.com/ntruchsess/perl-firmata allready supports this change in a backwards compatible way.
