### PR TITLE
For Review and Discussion: Alternate version of Shift with config command

### DIFF
--- a/examples/ConfigurableFirmata/ConfigurableFirmata.ino
+++ b/examples/ConfigurableFirmata/ConfigurableFirmata.ino
@@ -64,6 +64,9 @@ OneWireFirmata oneWire;
 #include <utility/StepperFirmata.h>
 StepperFirmata stepper;
 
+#include <utility/ShiftFirmata.h>
+ShiftFirmata shift;
+
 #include <utility/FirmataExt.h>
 FirmataExt firmataExt;
 
@@ -148,6 +151,9 @@ void setup()
 #ifdef StepperFirmata_h
   firmataExt.addFeature(stepper);
 #endif
+#ifdef ShiftFirmata_h
+  firmataExt.addFeature(shift);
+#endif  
 #ifdef FirmataReporting_h
   firmataExt.addFeature(reporting);
 #endif

--- a/utility/I2CFirmata.h
+++ b/utility/I2CFirmata.h
@@ -21,7 +21,6 @@
 #include <utility/FirmataFeature.h>
 #include <FirmataReporting.h>
 
-// move the following defines to Firmata.h?
 #define I2C_WRITE B00000000
 #define I2C_READ B00001000
 #define I2C_READ_CONTINUOUSLY B00010000

--- a/utility/ShiftFirmata.cpp
+++ b/utility/ShiftFirmata.cpp
@@ -3,7 +3,7 @@
   Copyright (C) 2006-2008 Hans-Christoph Steiner.  All rights reserved.
   Copyright (C) 2010-2011 Paul Stoffregen.  All rights reserved.
   Copyright (C) 2009 Shigeru Kobayashi.  All rights reserved.
-  Copyright (C) 2009-2011 Jeff Hoefs.  All rights reserved.
+  Copyright (C) 2009-2013 Jeff Hoefs.  All rights reserved.
   Copyright (C) 2013 Norbert Truchsess. All rights reserved.
 
   This library is free software; you can redistribute it and/or

--- a/utility/ShiftFirmata.cpp
+++ b/utility/ShiftFirmata.cpp
@@ -1,0 +1,116 @@
+/*
+  ShiftFirmata.cpp - Firmata library
+  Copyright (C) 2006-2008 Hans-Christoph Steiner.  All rights reserved.
+  Copyright (C) 2010-2011 Paul Stoffregen.  All rights reserved.
+  Copyright (C) 2009 Shigeru Kobayashi.  All rights reserved.
+  Copyright (C) 2009-2011 Jeff Hoefs.  All rights reserved.
+  Copyright (C) 2013 Norbert Truchsess. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  See file LICENSE.txt for further informations on licensing terms.
+*/
+
+#include <Firmata.h>
+#include <ShiftFirmata.h>
+#include <Encoder7Bit.h>
+
+boolean ShiftFirmata::handlePinMode(byte pin, int mode)
+{
+  if (IS_PIN_DIGITAL(pin)) {
+    if (mode == SHIFT) {
+      // pin modes for data, clock and latch pins need to be set separately
+      return true;
+    }
+  }
+  return false;
+}
+
+void ShiftFirmata::handleCapability(byte pin)
+{
+  if (IS_PIN_DIGITAL(pin)) {
+    Firmata.write(SHIFT);
+    Firmata.write(8); //8-bit resolution. Can send and receive multiple bytes.
+  }
+}
+
+boolean ShiftFirmata::handleSysex(byte command, byte argc, byte* argv)
+{
+  if(command == SHIFT_DATA) {
+    byte shiftCommand, dataPin, clockPin, latchPin, bitOrder;
+    byte shiftInData, shiftOutData;
+    int numBytes;
+
+    numBytes = 0;
+
+    shiftCommand = argv[0];
+    dataPin = argv[1];
+    clockPin = argv[2];
+    latchPin = argv[3];
+    bitOrder = argv[4];
+
+    // set only the data pin to SHIFT
+    if (Firmata.getPinMode(dataPin != SHIFT)) {
+      Firmata.setPinMode(dataPin, SHIFT);
+    }
+
+    if (shiftCommand == SHIFT_OUT) {
+      numBytes = num7BitOutbytes(argc - 5); // data starts after bitOrder (argv[4])
+      argv += 5;
+      Encoder7Bit.readBinary(numBytes, argv, argv); // decode in place
+
+      for (int i = 0; i < numBytes; i++) {
+        shiftOutData = argv[i];
+
+        digitalWrite(latchPin, LOW);
+        shiftOut(dataPin, clockPin, bitOrder, shiftOutData);
+        digitalWrite(latchPin, HIGH);
+      }
+
+    } else if (shiftCommand == SHIFT_IN) {
+      numBytes = argv[5];
+      Firmata.write(START_SYSEX);
+      Firmata.write(SHIFT_DATA);
+      Firmata.write(SHIFT_IN_REPLY);
+      Firmata.write(dataPin);
+      Encoder7Bit.startBinaryWrite();
+      for (int i = 0; i < numBytes; i++) {
+        digitalWrite(latchPin, LOW); // load bits
+        digitalWrite(latchPin, HIGH);
+
+        shiftInData = shift_In(dataPin, clockPin, bitOrder);
+        Encoder7Bit.writeBinary(shiftInData);
+      }
+      Encoder7Bit.endBinaryWrite();
+      Firmata.write(END_SYSEX);
+    }
+    return true;
+  }
+  return false;
+}
+
+// The built-in arduino shiftIn function doesn't work so we need our own.
+byte ShiftFirmata::shift_In(byte dataPin, byte clockPin, byte bitOrder)
+{
+  byte value = 0;
+  byte i;
+
+  for (i = 0; i < 8; i++) {
+    if (bitOrder == LSBFIRST)
+      value |= digitalRead(dataPin) << i;
+    else
+      value |= digitalRead(dataPin) << (7 - i);
+
+    digitalWrite(clockPin, HIGH);
+    digitalWrite(clockPin, LOW);
+  }
+  return value;
+}
+
+void ShiftFirmata::reset()
+{
+  // to do: any necessary cleanup
+}

--- a/utility/ShiftFirmata.cpp
+++ b/utility/ShiftFirmata.cpp
@@ -62,13 +62,12 @@ boolean ShiftFirmata::handleSysex(byte command, byte argc, byte* argv)
       argv += 5;
       Encoder7Bit.readBinary(numBytes, argv, argv); // decode in place
 
+      digitalWrite(latchPin, LOW);
       for (int i = 0; i < numBytes; i++) {
         shiftOutData = argv[i];
-
-        digitalWrite(latchPin, LOW);
         shiftOut(dataPin, clockPin, bitOrder, shiftOutData);
-        digitalWrite(latchPin, HIGH);
       }
+      digitalWrite(latchPin, HIGH);
 
     } else if (shiftCommand == SHIFT_IN) {
       numBytes = argv[5];

--- a/utility/ShiftFirmata.h
+++ b/utility/ShiftFirmata.h
@@ -27,7 +27,6 @@
 class ShiftFirmata:public FirmataFeature
 {
 public:
-  //ShiftFirmata();
   boolean handlePinMode(byte pin, int mode);
   void handleCapability(byte pin);
   boolean handleSysex(byte command, byte argc, byte* argv);

--- a/utility/ShiftFirmata.h
+++ b/utility/ShiftFirmata.h
@@ -20,9 +20,31 @@
 #include <Firmata.h>
 #include <utility/FirmataFeature.h>
 
-#define SHIFT_OUT 1
-#define SHIFT_IN 2
-#define SHIFT_IN_REPLY 3
+// shift commands
+#define SHIFT_CONFIG 1
+#define SHIFT_OUT 2
+#define SHIFT_IN 3
+#define SHIFT_IN_REPLY 4
+
+// shift types
+// SHIFT_OUT 2
+// SHIFT_IN 3
+#define LATCH_L_SHIFT_OUT 4
+#define SHIFT_OUT_LATCH_H 5
+#define LATCH_L_SHIFT_OUT_LATCH_H 6
+#define TOGGLE_LOAD_SHIFT_IN 7
+
+#define SHIFT_COMMAND_MASK  B00000111
+#define SHIFT_TYPE_MASK  B00111000
+
+struct shift_info
+{
+  byte type;
+  byte dataPin;
+  byte clockPin;
+  byte bitOrder;
+  byte latchPin; // optional
+};
 
 class ShiftFirmata:public FirmataFeature
 {
@@ -34,6 +56,7 @@ public:
 
 private:
   byte shift_In(byte dataPin, byte clockPin, byte bitOrder);
+  shift_info pinShift[TOTAL_PINS];
 };
 
 #endif

--- a/utility/ShiftFirmata.h
+++ b/utility/ShiftFirmata.h
@@ -1,0 +1,40 @@
+/*
+  ShiftFirmata.h - Firmata library
+  Copyright (C) 2006-2008 Hans-Christoph Steiner.  All rights reserved.
+  Copyright (C) 2010-2011 Paul Stoffregen.  All rights reserved.
+  Copyright (C) 2009 Shigeru Kobayashi.  All rights reserved.
+  Copyright (C) 2009-2013 Jeff Hoefs.  All rights reserved.
+  Copyright (C) 2013 Norbert Truchsess. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  See file LICENSE.txt for further informations on licensing terms.
+*/
+
+#ifndef ShiftFirmata_h
+#define ShiftFirmata_h
+
+#include <Firmata.h>
+#include <utility/FirmataFeature.h>
+
+#define SHIFT_OUT 1
+#define SHIFT_IN 2
+#define SHIFT_IN_REPLY 3
+
+class ShiftFirmata:public FirmataFeature
+{
+public:
+  //ShiftFirmata();
+  boolean handlePinMode(byte pin, int mode);
+  void handleCapability(byte pin);
+  boolean handleSysex(byte command, byte argc, byte* argv);
+  void reset();
+
+private:
+  byte shift_In(byte dataPin, byte clockPin, byte bitOrder);
+};
+
+#endif

--- a/utility/StepperFirmata.cpp
+++ b/utility/StepperFirmata.cpp
@@ -128,8 +128,6 @@ boolean StepperFirmata::handleSysex(byte command, byte argc, byte *argv)
 
 void StepperFirmata::reset()
 {
-  // initialize a defalt state
-  // TODO: option to load config from EEPROM instead of default
   for (byte i=0;i<MAX_STEPPERS;i++) {
     if (stepper[i]) {
       free(stepper[i]);


### PR DESCRIPTION
This is an alternative to the other shift implementation I have [proposed](https://github.com/firmata/arduino/pull/51). Please provide feedback. I'd like to settle on an implementation soon (either this config version or the other non-config version with no latch support or I'm open to other implementations as well if anyone else would like to submit a pull request).

The advantages with this version over the other one is that pinModes are handled by the implementation (in the other version you have to handle them manually). You also send fewer bytes when shifting out or in data (since only have to specify clock, bitOrder and optional latch pin once when sending the config). The disadvantage is that memory must be allocated for an array on the Arduino to store pin information.

There has also been some discussion around supporting fractional byte devices. This pull does not include such functionality, but tigercat was going to work on an implementation.

This version uses a SHIFT_CONFIG command to set the clock pin, bitOrder and optional latchPin (or load for some shift-in hardware). There are a few different shift types / latch configurations:

// shift types (specified in bits 3:5 of byte 2)
SHIFT_OUT                                     // shift out with no latch
SHIFT_IN                                         // shift out with no latch/load
LATCH_L_SHIFT_OUT                     // set latch low then shift out
LATCH_L_SHIFT_OUT_LATCH_H     // set latch low, shift out, then set latch high
SHIFT_OUT_LATCH_H                     // shift out then set latch high
TOGGLE_LOAD_SHIFT_IN               // toggle load pin low, then high and shift in

The protocol is as follows:
// shift config (send when instantiating a new shift-based hardware module)
0  START_SYSEX
1  SHIFT_DATA (0x75)
2  SHIFT_CONFIG  (bytes 0:2 shift command, bytes 3:5 shift type, byte 6 unused)
3  dataPin
4  clockPin
5  bitOrder
6  latchPin [optional]
7 END_SYSEX

// shift out
0  START_SYSEX
1  SHIFT_DATA (0x75)
2  SHIFT_OUT  (bytes 0:2 shift command, bytes 3:5 shift type, byte 6 unused)
3  dataPin
n  ... (shift out data)
n+1 END_SYSEX

// shift in
0  START_SYSEX
1  SHIFT_DATA (0x75)
2  SHIFT_IN  (bytes 0:2 shift command, bytes 3:5 shift type, byte 6 unused)
3  dataPin
4  numBytes (number of bytes to shift in. Default to 1)
5  END_SYSEX

Sample client implementation:
```
sendShiftConfig: function (shiftType, dataPin, clockPin, bitOrder, latchPin) {
  var shiftConfig = [];

  shiftConfig[0] = START_SYSEX;
  shiftConfig[1] = SHIFT_DATA;
  shiftConfig[2] = (shiftType << 3) | SHIFT_CONFIG;
  shiftConfig[3] = dataPin;
  shiftConfig[4] = clockPin;
  shiftConfig[5] = bitOrder || MSBFIRST;  

  if (latchPin && shiftType > 3) {
    shiftConfig[6] = latchPin;
  }

  shiftConfig.push(END_SYSEX);
  this.send(shiftConfig);
}

sendShiftIn: function (dataPin, numBytes) {
  var shiftIn = [];

  shiftIn[0] = START_SYSEX;
  shiftIn[1] = SHIFT_DATA;
  shiftIn[2] = SHIFT_IN;
  shiftIn[3] = dataPin;
  shiftIn[4] = numBytes || 1;
  shiftIn[5] = END_SYSEX;
  this.send(shiftIn);
}

sendShiftOut: function (dataPin, value) {
  var shiftOut = [], len;

  shiftOut[0] = START_SYSEX;
  shiftOut[1] = SHIFT_DATA;
  shiftOut[2] = SHIFT_OUT;
  shiftOut[3] = dataPin;

  this.encodeMultiByteValue(value);
  len = Encoder7Bit.binaryData.length;
  for (var i = 0; i < len; i++) {
    shiftOut.push(Encoder7Bit.binaryData[i]);
  }
  shiftOut.push(END_SYSEX);
  this.send(shiftOut);
}
```