### PR TITLE
restored Serial.begin(speed) to earlier version 

### DIFF
--- a/Firmata.cpp
+++ b/Firmata.cpp
@@ -67,14 +67,18 @@ void FirmataClass::begin(void)
 void FirmataClass::begin(long speed)
 {
   Serial.begin(speed);
-  begin(Serial);
-  blinkVersion();  
+  FirmataSerial = &Serial;
+  blinkVersion();
+  printVersion();
+  printFirmwareVersion();
 }
 
 /* begin method for overriding default stream */
 void FirmataClass::begin(Stream &s)
 {
   FirmataSerial = &s;
+  // do not call blinkVersion() here because some hardware such as the
+  // Ethernet shield use pin 13
   printVersion();
   printFirmwareVersion();
 }


### PR DESCRIPTION
This is so so blinkVersion is called at correct time. Had to remove call to begin(Serial) from begin(long speed) because we need FirmataSerial declared and don't want to call blinkVersion for the Stream version of the begin method. This is because hardware such as the ethernet shield use pin 13 (which is the blink pin on the Arduino Uno and similar boards).
