### PR TITLE
unify EthernetClientFirmata with ConfigurableFirmata

### DIFF
--- a/examples/ConfigurableFirmata/ConfigurableFirmata.ino
+++ b/examples/ConfigurableFirmata/ConfigurableFirmata.ino
@@ -3,7 +3,7 @@
  * from software on a host computer. It is intended to work with
  * any host computer software package.
  *
- * To download a host software package, please clink on the following link
+ * To download a host software package, please click on the following link
  * to open the download page in your default browser.
  *
  * http://firmata.org/wiki/Download

--- a/utility/EthernetClientStream.cpp
+++ b/utility/EthernetClientStream.cpp
@@ -1,3 +1,22 @@
+/*
+  EthernetClientStream.cpp
+  An Arduino-Stream that wraps an instance of Client reconnecting to
+  the remote-ip in a transparent way. A disconnected client may be
+  recognized by the returnvalues -1 from calls to peek or read and
+  a 0 from calls to write.
+
+  Copyright (C) 2013 Norbert Truchsess. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  See file LICENSE.txt for further informations on licensing terms.
+
+  formatted using the GNU C formatting and indenting
+ */
+
 #include "EthernetClientStream.h"
 #include <Arduino.h>
 #include <Ethernet.h>

--- a/utility/EthernetClientStream.h
+++ b/utility/EthernetClientStream.h
@@ -1,3 +1,22 @@
+/*
+  EthernetClientStream.h
+  An Arduino-Stream that wraps an instance of Client reconnecting to
+  the remote-ip in a transparent way. A disconnected client may be
+  recognized by the returnvalues -1 from calls to peek or read and
+  a 0 from calls to write.
+
+  Copyright (C) 2013 Norbert Truchsess. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  See file LICENSE.txt for further informations on licensing terms.
+
+  formatted using the GNU C formatting and indenting
+ */
+
 #ifndef ETHERNETCLIENTSTREAM_H
 #define ETHERNETCLIENTSTREAM_H
 


### PR DESCRIPTION
I refactored the Ethernet-client-handling into it's own class (implementing Stream). As a result it became quite easy to unify it with the ConfigurableFirmata.ino

Pull-request opend for review. (I also have to do more tests on my side before merge).
