### PR TITLE
force digital or analog message when enabling digital port or analog pin reporting

### DIFF
--- a/examples/StandardFirmata/StandardFirmata.ino
+++ b/examples/StandardFirmata/StandardFirmata.ino
@@ -349,6 +349,10 @@ void reportAnalogCallback(byte analogPin, int value)
       analogInputsToReport = analogInputsToReport &~ (1 << analogPin);
     } else {
       analogInputsToReport = analogInputsToReport | (1 << analogPin);
+      // Send pin value immediately. This is helpful when connected via
+      // ethernet, wi-fi or bluetooth so pin states can be known upon
+      // reconnecting.
+      Firmata.sendAnalog(analogPin, analogRead(analogPin));
     }
   }
   // TODO: save status to EEPROM here, if changed
@@ -358,6 +362,10 @@ void reportDigitalCallback(byte port, int value)
 {
   if (port < TOTAL_PORTS) {
     reportPINs[port] = (byte)value;
+    // Send port value immediately. This is helpful when connected via
+    // ethernet, wi-fi or bluetooth so pin states can be known upon
+    // reconnecting.
+    if (value) outputPort(port, readPort(port, portConfigInputs[port]), true);
   }
   // do not disable analog reporting on these 8 pins, to allow some
   // pins used for digital, others analog.  Instead, allow both types

--- a/extras/revisions.txt
+++ b/extras/revisions.txt
@@ -1,9 +1,6 @@
 FIRMATA 2.4.0 BETA - not yet released
 
 [core library]
-* Changed the way servo pins are mapped to enable use of servos on
-  a wider range of pins, including analog pins.
-* Updated FirmataServo example to use new pin mapping technique
 * Changed sendValueAsTwo7bitBytes, startSysex and endSysex from private to
   public methods.
 * Added Intel Galileo to Boards.h
@@ -22,6 +19,11 @@ FIRMATA 2.4.0 BETA - not yet released
 * Increased input data buffer size from 32 to 64 bytes
 
 [StandardFirmata]
+* When a digital port is enabled, its value is now immediately sent to the client
+* When an analog pin is enabled, its value is now immediately sent to the client
+* Changed the way servo pins are mapped to enable use of servos on
+  a wider range of pins, including analog pins.
+* Updated FirmataServo example to use new pin mapping technique
 * Fixed management of unexpected sized I2C replies (Nahuel Greco)
 * Fixed a bug when removing a monitored device with I2C_STOP_Reading (Nahuel Greco)
 * Fixed conditional expression in I2C_STOP_READING case


### PR DESCRIPTION
This change reports the digital port value upon the client enabling a digital port and it reports the analog pin value upon the client enabling that analog pin for reporting. This is a feature that has been [requested](https://github.com/firmata/arduino/issues/103) to better support non-serial based connections such as ethernet, wi-fi and bluetooth where it's possible the connection may be broken and reestablished. If a client library reenables analog pins and digital pins upon reestablishing a connection, then with this change the respective values will be reported so the client is updated with the current state of the pins. Care may be needed in the client library however to ensure that there are no false triggers due to the reported port and pin values.

This feature has been used in ConfigurableFirmata for almost a year with no issues reported.
