### PR TITLE
swapped HardwareSerial for Stream in Firmata.cpp

### DIFF
--- a/Firmata.cpp
+++ b/Firmata.cpp
@@ -15,7 +15,7 @@
 //******************************************************************************
 
 #include "Firmata.h"
-#include "HardwareSerial.h"
+#include "Stream.h"
 
 extern "C" {
 #include <string.h>

--- a/examples/AllInputsFirmata/AllInputsFirmata.ino
+++ b/examples/AllInputsFirmata/AllInputsFirmata.ino
@@ -15,6 +15,7 @@
  *
  * This example code is in the public domain.
  */
+#include <HardwareSerial.h> 
 #include <Firmata.h>
 
 byte pin;

--- a/examples/AnalogFirmata/AnalogFirmata.ino
+++ b/examples/AnalogFirmata/AnalogFirmata.ino
@@ -15,6 +15,7 @@
  * This example code is in the public domain.
  */
 #include <Servo.h>
+#include <HardwareSerial.h>
 #include <Firmata.h>
 
 /*==============================================================================

--- a/examples/EchoString/EchoString.ino
+++ b/examples/EchoString/EchoString.ino
@@ -13,6 +13,7 @@
  *
  * This example code is in the public domain.
  */
+#include <HardwareSerial.h> 
 #include <Firmata.h>
 
 void stringCallback(char *myString)

--- a/examples/OldStandardFirmata/OldStandardFirmata.ino
+++ b/examples/OldStandardFirmata/OldStandardFirmata.ino
@@ -28,6 +28,7 @@
  */
 
 #include <EEPROM.h>
+#include <HardwareSerial.h> 
 #include <Firmata.h>
 
 /*==============================================================================

--- a/examples/ServoFirmata/ServoFirmata.ino
+++ b/examples/ServoFirmata/ServoFirmata.ino
@@ -18,6 +18,7 @@
  */
  
 #include <Servo.h>
+#include <HardwareSerial.h> 
 #include <Firmata.h>
 
 Servo servos[MAX_SERVOS];

--- a/examples/SimpleAnalogFirmata/SimpleAnalogFirmata.ino
+++ b/examples/SimpleAnalogFirmata/SimpleAnalogFirmata.ino
@@ -13,6 +13,7 @@
  *
  * This example code is in the public domain.
  */
+#include <HardwareSerial.h> 
 #include <Firmata.h>
 
 byte analogPin = 0;

--- a/examples/SimpleDigitalFirmata/SimpleDigitalFirmata.ino
+++ b/examples/SimpleDigitalFirmata/SimpleDigitalFirmata.ino
@@ -13,6 +13,7 @@
  *
  * This example code is in the public domain.
  */
+#include <HardwareSerial.h> 
 #include <Firmata.h>
 
 byte previousPIN[TOTAL_PORTS];  // PIN means PORT for input

--- a/examples/StandardFirmata/StandardFirmata.ino
+++ b/examples/StandardFirmata/StandardFirmata.ino
@@ -31,6 +31,7 @@
 
 #include <Servo.h>
 #include <Wire.h>
+#include <HardwareSerial.h>
 #include <Firmata.h>
 
 // move the following defines to Firmata.h?


### PR DESCRIPTION
I realized that Firmata.cpp should include Stream.h rather than HardwareSerial.h since any type of Stream may be used with Firmata. I've updated the examples to include HardwareSerial.h before Firmata.h.

This change is going to break pretty much every existing sketch that uses Firmata with Serial but I think it's a worthwhile change going forward.

Thoughts?
