### PR TITLE
merge configurable_dev into configurable

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -6,7 +6,7 @@
 #include <inttypes.h>
 
 #if defined(ARDUINO) && ARDUINO >= 100
-#include "Arduino.h"	// for digitalRead, digitalWrite, etc
+#include "Arduino.h"  // for digitalRead, digitalWrite, etc
 #else
 #include "WProgram.h"
 #endif
@@ -23,7 +23,7 @@
     Firmata Hardware Abstraction Layer
 
 Firmata is built on top of the hardware abstraction functions of Arduino,
-specifically digitalWrite, digitalRead, analogWrite, analogRead, and 
+specifically digitalWrite, digitalRead, analogWrite, analogRead, and
 pinMode.  While these functions offer simple integer pin numbers, Firmata
 needs more information than is provided by Arduino.  This file provides
 all other hardware specific details.  To make Firmata support a new board,
@@ -165,7 +165,7 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #define PIN_TO_DIGITAL(p)       (p)
 #define PIN_TO_ANALOG(p)        ((p) - FIRST_ANALOG_PIN)
 #define PIN_TO_PWM(p)           PIN_TO_DIGITAL(p)
-#define PIN_TO_SERVO(p)         (p) 
+#define PIN_TO_SERVO(p)         (p)
 
 
 // old Arduinos
@@ -214,7 +214,7 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #define IS_PIN_PWM(p)           digitalPinHasPWM(p)
 #define IS_PIN_SERVO(p)         ((p) >= 2 && (p) - 2 < MAX_SERVOS)
 #define IS_PIN_I2C(p)           ((p) == 20 || (p) == 21) // 70 71
-#define IS_PIN_INTERRUPT(p)     IS_PIN_DIGITAL(p) 
+#define IS_PIN_INTERRUPT(p)     IS_PIN_DIGITAL(p)
 #define PIN_TO_DIGITAL(p)       (p)
 #define PIN_TO_ANALOG(p)        ((p) - 54)
 #define PIN_TO_PWM(p)           PIN_TO_DIGITAL(p)
@@ -271,7 +271,7 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #define PIN_TO_DIGITAL(p)       (p)
 #define PIN_TO_ANALOG(p)        (((p)<=23)?(p)-14:(p)-24)
 #define PIN_TO_PWM(p)           PIN_TO_DIGITAL(p)
-#define PIN_TO_SERVO(p)         (p) 
+#define PIN_TO_SERVO(p)         (p)
 
 
 // Teensy++ 1.0 and 2.0
@@ -307,7 +307,7 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #define PIN_TO_DIGITAL(p)       (p)
 #define PIN_TO_ANALOG(p)        (p) - 18
 #define PIN_TO_PWM(p)           PIN_TO_DIGITAL(p)
-#define PIN_TO_SERVO(p)         (p)  
+#define PIN_TO_SERVO(p)         (p)
 
 
 // Intel Galileo Board
@@ -320,7 +320,7 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #define IS_PIN_PWM(p)           digitalPinHasPWM(p)
 #define IS_PIN_SERVO(p)         (IS_PIN_DIGITAL(p) && (p) - 2 < MAX_SERVOS)
 #define IS_PIN_I2C(p)           ((p) == SDA || (p) == SCL)
-#define IS_PIN_SPI(p)           ((p) == SS || (p) == MOSI || (p) == MISO || (p) == SCK) 
+#define IS_PIN_SPI(p)           ((p) == SS || (p) == MOSI || (p) == MISO || (p) == SCK)
 #define PIN_TO_DIGITAL(p)       (p)
 #define PIN_TO_ANALOG(p)        ((p) - 14)
 #define PIN_TO_PWM(p)           PIN_TO_DIGITAL(p)
@@ -379,21 +379,21 @@ static inline unsigned char readPort(byte, byte) __attribute__((always_inline, u
 static inline unsigned char readPort(byte port, byte bitmask)
 {
 #if defined(ARDUINO_PINOUT_OPTIMIZE)
-	if (port == 0) return (PIND & 0xFC) & bitmask; // ignore Rx/Tx 0/1
-	if (port == 1) return ((PINB & 0x3F) | ((PINC & 0x03) << 6)) & bitmask;
-	if (port == 2) return ((PINC & 0x3C) >> 2) & bitmask;
-	return 0;
+  if (port == 0) return (PIND & 0xFC) & bitmask; // ignore Rx/Tx 0/1
+  if (port == 1) return ((PINB & 0x3F) | ((PINC & 0x03) << 6)) & bitmask;
+  if (port == 2) return ((PINC & 0x3C) >> 2) & bitmask;
+  return 0;
 #else
-	unsigned char out=0, pin=port*8;
-	if (IS_PIN_DIGITAL(pin+0) && (bitmask & 0x01) && digitalRead(PIN_TO_DIGITAL(pin+0))) out |= 0x01;
-	if (IS_PIN_DIGITAL(pin+1) && (bitmask & 0x02) && digitalRead(PIN_TO_DIGITAL(pin+1))) out |= 0x02;
-	if (IS_PIN_DIGITAL(pin+2) && (bitmask & 0x04) && digitalRead(PIN_TO_DIGITAL(pin+2))) out |= 0x04;
-	if (IS_PIN_DIGITAL(pin+3) && (bitmask & 0x08) && digitalRead(PIN_TO_DIGITAL(pin+3))) out |= 0x08;
-	if (IS_PIN_DIGITAL(pin+4) && (bitmask & 0x10) && digitalRead(PIN_TO_DIGITAL(pin+4))) out |= 0x10;
-	if (IS_PIN_DIGITAL(pin+5) && (bitmask & 0x20) && digitalRead(PIN_TO_DIGITAL(pin+5))) out |= 0x20;
-	if (IS_PIN_DIGITAL(pin+6) && (bitmask & 0x40) && digitalRead(PIN_TO_DIGITAL(pin+6))) out |= 0x40;
-	if (IS_PIN_DIGITAL(pin+7) && (bitmask & 0x80) && digitalRead(PIN_TO_DIGITAL(pin+7))) out |= 0x80;
-	return out;
+  unsigned char out = 0, pin = port * 8;
+  if (IS_PIN_DIGITAL(pin + 0) && (bitmask & 0x01) && digitalRead(PIN_TO_DIGITAL(pin + 0))) out |= 0x01;
+  if (IS_PIN_DIGITAL(pin + 1) && (bitmask & 0x02) && digitalRead(PIN_TO_DIGITAL(pin + 1))) out |= 0x02;
+  if (IS_PIN_DIGITAL(pin + 2) && (bitmask & 0x04) && digitalRead(PIN_TO_DIGITAL(pin + 2))) out |= 0x04;
+  if (IS_PIN_DIGITAL(pin + 3) && (bitmask & 0x08) && digitalRead(PIN_TO_DIGITAL(pin + 3))) out |= 0x08;
+  if (IS_PIN_DIGITAL(pin + 4) && (bitmask & 0x10) && digitalRead(PIN_TO_DIGITAL(pin + 4))) out |= 0x10;
+  if (IS_PIN_DIGITAL(pin + 5) && (bitmask & 0x20) && digitalRead(PIN_TO_DIGITAL(pin + 5))) out |= 0x20;
+  if (IS_PIN_DIGITAL(pin + 6) && (bitmask & 0x40) && digitalRead(PIN_TO_DIGITAL(pin + 6))) out |= 0x40;
+  if (IS_PIN_DIGITAL(pin + 7) && (bitmask & 0x80) && digitalRead(PIN_TO_DIGITAL(pin + 7))) out |= 0x80;
+  return out;
 #endif
 }
 
@@ -405,42 +405,47 @@ static inline unsigned char writePort(byte, byte, byte) __attribute__((always_in
 static inline unsigned char writePort(byte port, byte value, byte bitmask)
 {
 #if defined(ARDUINO_PINOUT_OPTIMIZE)
-	if (port == 0) {
-		bitmask = bitmask & 0xFC;  // do not touch Tx & Rx pins
-		byte valD = value & bitmask;
-		byte maskD = ~bitmask;
-		cli();
-		PORTD = (PORTD & maskD) | valD;
-		sei();
-	} else if (port == 1) {
-		byte valB = (value & bitmask) & 0x3F;
-		byte valC = (value & bitmask) >> 6;
-		byte maskB = ~(bitmask & 0x3F);
-		byte maskC = ~((bitmask & 0xC0) >> 6);
-		cli();
-		PORTB = (PORTB & maskB) | valB;
-		PORTC = (PORTC & maskC) | valC;
-		sei();
-	} else if (port == 2) {
-		bitmask = bitmask & 0x0F;
-		byte valC = (value & bitmask) << 2;
-		byte maskC = ~(bitmask << 2);
-		cli();
-		PORTC = (PORTC & maskC) | valC;
-		sei();
-	}
-    return 1;
+  if (port == 0)
+  {
+    bitmask = bitmask & 0xFC;  // do not touch Tx & Rx pins
+    byte valD = value & bitmask;
+    byte maskD = ~bitmask;
+    cli();
+    PORTD = (PORTD & maskD) | valD;
+    sei();
+  }
+  else if (port == 1)
+  {
+    byte valB = (value & bitmask) & 0x3F;
+    byte valC = (value & bitmask) >> 6;
+    byte maskB = ~(bitmask & 0x3F);
+    byte maskC = ~((bitmask & 0xC0) >> 6);
+    cli();
+    PORTB = (PORTB & maskB) | valB;
+    PORTC = (PORTC & maskC) | valC;
+    sei();
+  }
+  else if (port == 2)
+  {
+    bitmask = bitmask & 0x0F;
+    byte valC = (value & bitmask) << 2;
+    byte maskC = ~(bitmask << 2);
+    cli();
+    PORTC = (PORTC & maskC) | valC;
+    sei();
+  }
+  return 1;
 #else
-	byte pin=port*8;
-	if ((bitmask & 0x01)) digitalWrite(PIN_TO_DIGITAL(pin+0), (value & 0x01));
-	if ((bitmask & 0x02)) digitalWrite(PIN_TO_DIGITAL(pin+1), (value & 0x02));
-	if ((bitmask & 0x04)) digitalWrite(PIN_TO_DIGITAL(pin+2), (value & 0x04));
-	if ((bitmask & 0x08)) digitalWrite(PIN_TO_DIGITAL(pin+3), (value & 0x08));
-	if ((bitmask & 0x10)) digitalWrite(PIN_TO_DIGITAL(pin+4), (value & 0x10));
-	if ((bitmask & 0x20)) digitalWrite(PIN_TO_DIGITAL(pin+5), (value & 0x20));
-	if ((bitmask & 0x40)) digitalWrite(PIN_TO_DIGITAL(pin+6), (value & 0x40));
-	if ((bitmask & 0x80)) digitalWrite(PIN_TO_DIGITAL(pin+7), (value & 0x80));
-    return 1;
+  byte pin = port * 8;
+  if ((bitmask & 0x01)) digitalWrite(PIN_TO_DIGITAL(pin + 0), (value & 0x01));
+  if ((bitmask & 0x02)) digitalWrite(PIN_TO_DIGITAL(pin + 1), (value & 0x02));
+  if ((bitmask & 0x04)) digitalWrite(PIN_TO_DIGITAL(pin + 2), (value & 0x04));
+  if ((bitmask & 0x08)) digitalWrite(PIN_TO_DIGITAL(pin + 3), (value & 0x08));
+  if ((bitmask & 0x10)) digitalWrite(PIN_TO_DIGITAL(pin + 4), (value & 0x10));
+  if ((bitmask & 0x20)) digitalWrite(PIN_TO_DIGITAL(pin + 5), (value & 0x20));
+  if ((bitmask & 0x40)) digitalWrite(PIN_TO_DIGITAL(pin + 6), (value & 0x40));
+  if ((bitmask & 0x80)) digitalWrite(PIN_TO_DIGITAL(pin + 7), (value & 0x80));
+  return 1;
 #endif
 }
 

--- a/Firmata.h
+++ b/Firmata.h
@@ -1,7 +1,7 @@
 /*
-  Firmata.h - Firmata library v2.6.0 - 2014-03-08
+  Firmata.h - Firmata library v2.6.1 - 2014-12-28
   Copyright (C) 2006-2008 Hans-Christoph Steiner.  All rights reserved.
- 
+
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
   License as published by the Free Software Foundation; either
@@ -21,7 +21,7 @@
  * installed firmware. */
 #define FIRMATA_MAJOR_VERSION   2 // for non-compatible changes
 #define FIRMATA_MINOR_VERSION   6 // for backwards compatible changes
-#define FIRMATA_BUGFIX_VERSION  0 // for bugfix releases
+#define FIRMATA_BUGFIX_VERSION  1 // for bugfix releases
 
 #define MAX_DATA_BYTES          64 // max number of data bytes in incoming messages
 
@@ -84,12 +84,12 @@
 #define TOTAL_PIN_MODES         11
 
 extern "C" {
-// callback function types
-    typedef void (*callbackFunction)(byte, int);
-    typedef void (*systemResetCallbackFunction)(void);
-    typedef void (*stringCallbackFunction)(char*);
-    typedef void (*sysexCallbackFunction)(byte command, byte argc, byte*argv);
-    typedef void (*delayTaskCallbackFunction)(long delay);
+  // callback function types
+  typedef void (*callbackFunction)(byte, int);
+  typedef void (*systemResetCallbackFunction)(void);
+  typedef void (*stringCallbackFunction)(char *);
+  typedef void (*sysexCallbackFunction)(byte command, byte argc, byte *argv);
+  typedef void (*delayTaskCallbackFunction)(long delay);
 }
 
 
@@ -97,82 +97,82 @@ extern "C" {
 class FirmataClass
 {
 public:
-    FirmataClass();
-/* Arduino constructors */
-    void begin();
-    void begin(long);
-    void begin(Stream &s);
-/* querying functions */
-    void printVersion(void);
-    void blinkVersion(void);
-    void printFirmwareVersion(void);
+  FirmataClass();
+  /* Arduino constructors */
+  void begin();
+  void begin(long);
+  void begin(Stream &s);
+  /* querying functions */
+  void printVersion(void);
+  void blinkVersion(void);
+  void printFirmwareVersion(void);
   //void setFirmwareVersion(byte major, byte minor);  // see macro below
-    void setFirmwareNameAndVersion(const char *name, byte major, byte minor);
-/* serial receive handling */
-    int available(void);
-    void processInput(void);
-    void parse(unsigned char value);
-    boolean isParsingMessage(void);
-/* serial send handling */
-    void sendAnalog(byte pin, int value);
-    void sendDigital(byte pin, int value); // TODO implement this
-    void sendDigitalPort(byte portNumber, int portData);
-    void sendString(const char* string);
-    void sendString(byte command, const char* string);
-    void sendSysex(byte command, byte bytec, byte* bytev);
-    void write(byte c);
-/* attach & detach callback functions to messages */
-    void attach(byte command, callbackFunction newFunction);
-    void attach(byte command, systemResetCallbackFunction newFunction);
-    void attach(byte command, stringCallbackFunction newFunction);
-    void attach(byte command, sysexCallbackFunction newFunction);
-    void detach(byte command);
-/* delegate to Scheduler (if any) */
-    void attachDelayTask(delayTaskCallbackFunction newFunction);
-    void delayTask(long delay);
-/* access pin config */
-    byte getPinMode(byte pin);
-    void setPinMode(byte pin, byte config);
-/* access pin state */
-    int getPinState(byte pin);
-    void setPinState(byte pin, int state);
+  void setFirmwareNameAndVersion(const char *name, byte major, byte minor);
+  /* serial receive handling */
+  int available(void);
+  void processInput(void);
+  void parse(unsigned char value);
+  boolean isParsingMessage(void);
+  /* serial send handling */
+  void sendAnalog(byte pin, int value);
+  void sendDigital(byte pin, int value); // TODO implement this
+  void sendDigitalPort(byte portNumber, int portData);
+  void sendString(const char *string);
+  void sendString(byte command, const char *string);
+  void sendSysex(byte command, byte bytec, byte *bytev);
+  void write(byte c);
+  /* attach & detach callback functions to messages */
+  void attach(byte command, callbackFunction newFunction);
+  void attach(byte command, systemResetCallbackFunction newFunction);
+  void attach(byte command, stringCallbackFunction newFunction);
+  void attach(byte command, sysexCallbackFunction newFunction);
+  void detach(byte command);
+  /* delegate to Scheduler (if any) */
+  void attachDelayTask(delayTaskCallbackFunction newFunction);
+  void delayTask(long delay);
+  /* access pin config */
+  byte getPinMode(byte pin);
+  void setPinMode(byte pin, byte config);
+  /* access pin state */
+  int getPinState(byte pin);
+  void setPinState(byte pin, int state);
 
 
 private:
-    Stream *FirmataStream;
-/* firmware name and version */
-    byte firmwareVersionCount;
-    byte *firmwareVersionVector;
-/* input message handling */
-    byte waitForData; // this flag says the next serial input will be data
-    byte executeMultiByteCommand; // execute this after getting multi-byte data
-    byte multiByteChannel; // channel data for multiByteCommands
-    byte storedInputData[MAX_DATA_BYTES]; // multi-byte data
-/* sysex */
-    boolean parsingSysex;
-    int sysexBytesRead;
-/* pins configuration */
-    byte pinConfig[TOTAL_PINS];         // configuration of every pin
-    int pinState[TOTAL_PINS];           // any value that has been written
+  Stream *FirmataStream;
+  /* firmware name and version */
+  byte firmwareVersionCount;
+  byte *firmwareVersionVector;
+  /* input message handling */
+  byte waitForData; // this flag says the next serial input will be data
+  byte executeMultiByteCommand; // execute this after getting multi-byte data
+  byte multiByteChannel; // channel data for multiByteCommands
+  byte storedInputData[MAX_DATA_BYTES]; // multi-byte data
+  /* sysex */
+  boolean parsingSysex;
+  int sysexBytesRead;
+  /* pins configuration */
+  byte pinConfig[TOTAL_PINS];         // configuration of every pin
+  int pinState[TOTAL_PINS];           // any value that has been written
 
-/* callback functions */
-    callbackFunction currentAnalogCallback;
-    callbackFunction currentDigitalCallback;
-    callbackFunction currentReportAnalogCallback;
-    callbackFunction currentReportDigitalCallback;
-    callbackFunction currentPinModeCallback;
-    systemResetCallbackFunction currentSystemResetCallback;
-    stringCallbackFunction currentStringCallback;
-    sysexCallbackFunction currentSysexCallback;
-    delayTaskCallbackFunction delayTaskCallback;
+  /* callback functions */
+  callbackFunction currentAnalogCallback;
+  callbackFunction currentDigitalCallback;
+  callbackFunction currentReportAnalogCallback;
+  callbackFunction currentReportDigitalCallback;
+  callbackFunction currentPinModeCallback;
+  systemResetCallbackFunction currentSystemResetCallback;
+  stringCallbackFunction currentStringCallback;
+  sysexCallbackFunction currentSysexCallback;
+  delayTaskCallbackFunction delayTaskCallback;
 
-/* private methods ------------------------------ */
-    void processSysexMessage(void);
-    void systemReset(void);
-    void strobeBlinkPin(int count, int onInterval, int offInterval);
-    void sendValueAsTwo7bitBytes(int value);
-    void startSysex(void);
-    void endSysex(void);
+  /* private methods ------------------------------ */
+  void processSysexMessage(void);
+  void systemReset(void);
+  void strobeBlinkPin(int count, int onInterval, int offInterval);
+  void sendValueAsTwo7bitBytes(int value);
+  void startSysex(void);
+  void endSysex(void);
 };
 
 extern FirmataClass Firmata;

--- a/examples/StandardFirmata/StandardFirmata.ino
+++ b/examples/StandardFirmata/StandardFirmata.ino
@@ -70,7 +70,7 @@ unsigned int samplingInterval = 19;          // how often to run the main loop (
 /* i2c data */
 struct i2c_device_info {
   byte addr;
-  byte reg;
+  int reg;
   byte bytes;
 };
 
@@ -329,10 +329,10 @@ void sysexCallback(byte command, byte argc, byte *argv)
 {
   byte mode;
   byte slaveAddress;
-  byte slaveRegister;
   byte data;
-  unsigned int delayTime; 
-  
+  int slaveRegister;
+  unsigned int delayTime;
+
   switch(command) {
   case I2C_REQUEST:
     mode = argv[1] & I2C_READ_WRITE_MODE_MASK;
@@ -363,13 +363,13 @@ void sysexCallback(byte command, byte argc, byte *argv)
         // a slave register is specified
         slaveRegister = argv[2] + (argv[3] << 7);
         data = argv[4] + (argv[5] << 7);  // bytes to read
-        readAndReportData(slaveAddress, (int)slaveRegister, data);
       }
       else {
         // a slave register is NOT specified
+        slaveRegister = REGISTER_NOT_SPECIFIED;
         data = argv[2] + (argv[3] << 7);  // bytes to read
-        readAndReportData(slaveAddress, (int)REGISTER_NOT_SPECIFIED, data);
       }
+      readAndReportData(slaveAddress, (int)slaveRegister, data);
       break;
     case I2C_READ_CONTINUOUSLY:
       if ((queryIndex + 1) >= MAX_QUERIES) {
@@ -377,10 +377,20 @@ void sysexCallback(byte command, byte argc, byte *argv)
         Firmata.sendString("too many queries");
         break;
       }
+      if (argc == 6) {
+        // a slave register is specified
+        slaveRegister = argv[2] + (argv[3] << 7);
+        data = argv[4] + (argv[5] << 7);  // bytes to read
+      }
+      else {
+        // a slave register is NOT specified
+        slaveRegister = (int)REGISTER_NOT_SPECIFIED;
+        data = argv[2] + (argv[3] << 7);  // bytes to read
+      }
       queryIndex++;
       query[queryIndex].addr = slaveAddress;
-      query[queryIndex].reg = argv[2] + (argv[3] << 7);
-      query[queryIndex].bytes = argv[4] + (argv[5] << 7);
+      query[queryIndex].reg = slaveRegister;
+      query[queryIndex].bytes = data;
       break;
     case I2C_STOP_READING:
       byte queryIndexToSkip;      

--- a/library.properties
+++ b/library.properties
@@ -1,8 +1,8 @@
 name=Firmata
-version=2.6.0
+version=2.6.1
 author=Firmata Developers
-maintainer=firmata-devel@lists.sourceforge.net
+maintainer=https://github.com/firmata/arduino
 sentence=This library implements the Firmata protocol and allows you to control the Arduino board from the an application on the computer.
 paragraph=The Firmata library implements the Firmata protocol for communicating with software on the host computer. This allows you to write custom firmware without having to create your own protocol and objects for the programming environment that you are using.
-url=http://firmata.org
+url=https://github.com/firmata/arduino
 architectures=*

--- a/release.sh
+++ b/release.sh
@@ -17,7 +17,7 @@ cd temp
 find . -name "*.DS_Store" -type f -delete
 zip -r Firmata.zip ./Firmata/
 cd ..
-mv ./temp/Firmata.zip Firmata-2.6.0.zip
+mv ./temp/Firmata.zip Firmata-2.6.1.zip
 
 # package for Arduino 1.5.x
 cd temp/Firmata
@@ -30,5 +30,5 @@ cd ..
 find . -name "*.DS_Store" -type f -delete
 zip -r Firmata.zip ./Firmata/
 cd ..
-mv ./temp/Firmata.zip Arduino-1.5.x-Firmata-2.6.0.zip
+mv ./temp/Firmata.zip Arduino-1.5.x-Firmata-2.6.1.zip
 rm -r ./temp

--- a/release.sh
+++ b/release.sh
@@ -1,9 +1,8 @@
 #!/bin/sh
 
 # use this script to package Firmata for distribution
-# to do: make an ant script or something else that is cross platform
 
-# create distribution package for Arduino 1.0.x and Arduino 1.5.x
+# package for Arduino 1.0.x
 mkdir -p temp/Firmata
 cp -r examples temp/Firmata
 cp -r extras temp/Firmata
@@ -12,10 +11,24 @@ cp Boards.h temp/Firmata
 cp Firmata.cpp temp/Firmata
 cp Firmata.h temp/Firmata
 cp keywords.txt temp/Firmata
-cp readme.md temp/Firmata
+cp readme.md temp/Firmata/extras
+cp library.properties temp/Firmata
 cd temp
 find . -name "*.DS_Store" -type f -delete
 zip -r Firmata.zip ./Firmata/
 cd ..
 mv ./temp/Firmata.zip Firmata-2.6.0.zip
+
+# package for Arduino 1.5.x
+cd temp/Firmata
+mkdir src
+mv Boards.h ./src/
+mv Firmata.cpp ./src/
+mv Firmata.h ./src/
+mv utility ./src/
+cd ..
+find . -name "*.DS_Store" -type f -delete
+zip -r Firmata.zip ./Firmata/
+cd ..
+mv ./temp/Firmata.zip Arduino-1.5.x-Firmata-2.6.0.zip
 rm -r ./temp

--- a/utility/AnalogFirmata.cpp
+++ b/utility/AnalogFirmata.cpp
@@ -15,7 +15,7 @@
 */
 
 #include <Firmata.h>
-#include <AnalogFirmata.h>
+#include "AnalogFirmata.h"
 
 boolean handleAnalogFirmataSysex(byte command, byte argc, byte* argv)
 {

--- a/utility/AnalogInputFirmata.cpp
+++ b/utility/AnalogInputFirmata.cpp
@@ -15,8 +15,8 @@
 */
 
 #include <Firmata.h>
-#include <AnalogFirmata.h>
-#include <AnalogInputFirmata.h>
+#include "AnalogFirmata.h"
+#include "AnalogInputFirmata.h"
 
 AnalogInputFirmata *AnalogInputFirmataInstance;
 

--- a/utility/AnalogInputFirmata.h
+++ b/utility/AnalogInputFirmata.h
@@ -18,8 +18,8 @@
 #define AnalogInputFirmata_h
 
 #include <Firmata.h>
-#include <utility/FirmataFeature.h>
-#include <utility/FirmataReporting.h>
+#include "FirmataFeature.h"
+#include "FirmataReporting.h"
 
 void reportAnalogInputCallback(byte analogPin, int value);
 

--- a/utility/AnalogOutputFirmata.cpp
+++ b/utility/AnalogOutputFirmata.cpp
@@ -15,8 +15,8 @@
 */
 
 #include <Firmata.h>
-#include <AnalogFirmata.h>
-#include <AnalogOutputFirmata.h>
+#include "AnalogFirmata.h"
+#include "AnalogOutputFirmata.h"
 
 //AnalogOutputFirmata::AnalogOutputFirmata()
 //{

--- a/utility/AnalogOutputFirmata.h
+++ b/utility/AnalogOutputFirmata.h
@@ -18,7 +18,7 @@
 #define AnalogOutputFirmata_h
 
 #include <Firmata.h>
-#include <utility/FirmataFeature.h>
+#include "FirmataFeature.h"
 
 class AnalogOutputFirmata:public FirmataFeature
 {

--- a/utility/DigitalInputFirmata.cpp
+++ b/utility/DigitalInputFirmata.cpp
@@ -15,7 +15,7 @@
 */
 
 #include <Firmata.h>
-#include <DigitalInputFirmata.h>
+#include "DigitalInputFirmata.h"
 
 DigitalInputFirmata *DigitalInputFirmataInstance;
 

--- a/utility/DigitalInputFirmata.h
+++ b/utility/DigitalInputFirmata.h
@@ -18,7 +18,7 @@
 #define DigitalInputFirmata_h
 
 #include <Firmata.h>
-#include <utility/FirmataFeature.h>
+#include "FirmataFeature.h"
 
 void reportDigitalInputCallback(byte port, int value);
 

--- a/utility/DigitalOutputFirmata.cpp
+++ b/utility/DigitalOutputFirmata.cpp
@@ -15,7 +15,7 @@
 */
 
 #include <Firmata.h>
-#include <DigitalOutputFirmata.h>
+#include "DigitalOutputFirmata.h"
 
 DigitalOutputFirmata *DigitalOutputFirmataInstance;
 

--- a/utility/DigitalOutputFirmata.h
+++ b/utility/DigitalOutputFirmata.h
@@ -18,7 +18,7 @@
 #define DigitalOutputFirmata_h
 
 #include <Firmata.h>
-#include <utility/FirmataFeature.h>
+#include "FirmataFeature.h"
 
 void digitalOutputWriteCallback(byte port, int value);
 

--- a/utility/FirmataExt.cpp
+++ b/utility/FirmataExt.cpp
@@ -15,7 +15,7 @@
 */
 
 #include <Firmata.h>
-#include <FirmataExt.h>
+#include "FirmataExt.h"
 
 FirmataExt *FirmataExtInstance;
 

--- a/utility/FirmataExt.h
+++ b/utility/FirmataExt.h
@@ -18,7 +18,7 @@
 #define FirmataExt_h
 
 #include <Firmata.h>
-#include <utility/FirmataFeature.h>
+#include "FirmataFeature.h"
 
 #define MAX_FEATURES TOTAL_PIN_MODES+1
 

--- a/utility/FirmataReporting.cpp
+++ b/utility/FirmataReporting.cpp
@@ -15,8 +15,8 @@
 */
 
 #include <Firmata.h>
-#include <utility/FirmataFeature.h>
-#include <FirmataReporting.h>
+#include "FirmataFeature.h"
+#include "FirmataReporting.h"
 
 void FirmataReporting::setSamplingInterval(int interval)
 {

--- a/utility/FirmataReporting.h
+++ b/utility/FirmataReporting.h
@@ -18,7 +18,7 @@
 #define FirmataReporting_h
 
 #include <Firmata.h>
-#include <utility/FirmataFeature.h>
+#include "FirmataFeature.h"
 
 #define MINIMUM_SAMPLING_INTERVAL 10
 

--- a/utility/FirmataScheduler.cpp
+++ b/utility/FirmataScheduler.cpp
@@ -11,10 +11,10 @@
 */
 
 #include <Firmata.h>
-#include <utility/FirmataFeature.h>
-#include <Encoder7Bit.h>
-#include <FirmataScheduler.h>
-#include <FirmataExt.h>
+#include "FirmataFeature.h"
+#include "Encoder7Bit.h"
+#include "FirmataScheduler.h"
+#include "FirmataExt.h"
 
 FirmataScheduler *FirmataSchedulerInstance;
 

--- a/utility/FirmataScheduler.h
+++ b/utility/FirmataScheduler.h
@@ -14,8 +14,8 @@
 #define FirmataScheduler_h
 
 #include <Firmata.h>
-#include <utility/FirmataFeature.h>
-#include <utility/Encoder7Bit.h>
+#include "FirmataFeature.h"
+#include "Encoder7Bit.h"
 
 //subcommands
 #define CREATE_FIRMATA_TASK     0

--- a/utility/FirmataStepper.cpp
+++ b/utility/FirmataStepper.cpp
@@ -1,17 +1,17 @@
 /**
   FirmataStepper is a simple non-blocking stepper motor library
   for 2 and 4 wire bipolar and unipolar stepper motor drive circuits
-  as well as EasyDriver (http://schmalzhaus.com/EasyDriver/) and 
+  as well as EasyDriver (http://schmalzhaus.com/EasyDriver/) and
   other step + direction drive circuits.
 
-  FirmataStepper (0.1) by Jeff Hoefs
-  
+  FirmataStepper (0.2) by Jeff Hoefs
+
   EasyDriver support based on modifications by Chris Coleman
 
   Acceleration / Deceleration algorithms and code based on:
   app note: http://www.atmel.com/dyn/resources/prod_documents/doc8017.pdf
   source code: http://www.atmel.com/dyn/resources/prod_documents/AVR446.zip
-  
+
   stepMotor function based on Stepper.cpp Stepper library for
   Wiring/Arduino created by Tom Igoe, Sebastian Gassner
   David Mellis and Noah Shibley.
@@ -19,11 +19,11 @@
   Relevant notes from Stepper.cpp:
 
   When wiring multiple stepper motors to a microcontroller,
-  you quickly run out of output pins, with each motor requiring 4 connections. 
+  you quickly run out of output pins, with each motor requiring 4 connections.
 
   By making use of the fact that at any time two of the four motor
   coils are the inverse  of the other two, the number of
-  control connections can be reduced from 4 to 2. 
+  control connections can be reduced from 4 to 2.
 
   A slightly modified circuit around a Darlington transistor array or an L293 H-bridge
   connects to only 2 microcontroler pins, inverts the signals received,
@@ -47,7 +47,7 @@
      3  1  0
      4  0  0
 
-  The circuits can be found at 
+  The circuits can be found at
   http://www.arduino.cc/en/Tutorial/Stepper
 */
 
@@ -59,28 +59,42 @@
  * Configure a stepper for an EasyDriver or other step + direction interface or
  * configure a bipolar or unipolar stepper motor for 2 wire drive mode.
  * Configure a bipolar or unipolar stepper for 4 wire drive mode.
- * @param interface The interface type: FirmataStepper::DRIVER or
- * FirmataStepper::TWO_WIRE
+ * @param interface Lower 3 bits:
+ * The interface type: FirmataStepper::DRIVER,
+ * FirmataStepper::TWO_WIRE or FirmataStepper::FOUR_WIRE
+ * Upper 4 bits: Any bits set = use 2 microsecond delay
  * @param steps_per_rev The number of steps to make 1 revolution.
- * @param first_pin The direction pin (EasyDriver) or the pin attached to the 
+ * @param first_pin The direction pin (EasyDriver) or the pin attached to the
  * 1st motor coil (2 wire drive mode)
- * @param second_pin The step pin (EasyDriver) or the pin attached to the 2nd 
+ * @param second_pin The step pin (EasyDriver) or the pin attached to the 2nd
  * motor coil (2 wire drive mode)
  * @param motor_pin_3 The pin attached to the 3rd motor coil
- * @param motor_pin_4 The pin attached to the 4th motor coil 
+ * @param motor_pin_4 The pin attached to the 4th motor coil
  */
-FirmataStepper::FirmataStepper(byte interface, 
-                              int steps_per_rev, 
-                              byte pin1, 
-                              byte pin2, 
-                              byte pin3, 
-                              byte pin4) {
+FirmataStepper::FirmataStepper(byte interface,
+                               int steps_per_rev,
+                               byte pin1,
+                               byte pin2,
+                               byte pin3,
+                               byte pin4)
+{
   this->step_number = 0;      // which step the motor is on
   this->direction = 0;      // motor direction
   this->last_step_time = 0;    // time stamp in ms of the last step taken
   this->steps_per_rev = steps_per_rev;    // total number of steps for this motor
   this->running = false;
-  this->interface = interface; // default to Easy Stepper (or other step + direction driver)
+  this->interface = interface & 0x0F; // default to Easy Stepper (or other step + direction driver)
+
+  // could update this in future to support additional delays if necessary
+  if (((interface & 0xF0) >> 4) > 0)
+  {
+    // high current driver
+    this->stepDelay = 2; // microseconds
+  }
+  else
+  {
+    this->stepDelay = 1; // microseconds
+  }
 
   this->motor_pin_1 = pin1;
   this->motor_pin_2 = pin2;
@@ -91,17 +105,18 @@ FirmataStepper::FirmataStepper(byte interface,
   pinMode(this->motor_pin_1, OUTPUT);
   pinMode(this->motor_pin_2, OUTPUT);
 
-  if (interface == FirmataStepper::FOUR_WIRE) {
+  if (this->interface == FirmataStepper::FOUR_WIRE)
+  {
     this->motor_pin_3 = pin3;
-    this->motor_pin_4 = pin4;    
+    this->motor_pin_4 = pin4;
     pinMode(this->motor_pin_3, OUTPUT);
-    pinMode(this->motor_pin_4, OUTPUT);      
+    pinMode(this->motor_pin_4, OUTPUT);
   }
 
 
-  this->alpha = PI_2/this->steps_per_rev;
+  this->alpha = PI_2 / this->steps_per_rev;
   this->at_x100 = (long)(this->alpha * T1_FREQ * 100);
-  this->ax20000 = (long)(this->alpha*20000);
+  this->ax20000 = (long)(this->alpha * 20000);
   this->alpha_x2 = this->alpha * 2;
 
 }
@@ -111,24 +126,27 @@ FirmataStepper::FirmataStepper(byte interface,
  * speed (rad/sec), acceleration (rad/sec^2) and deceleration (rad/sec^2).
  *
  * @param steps_to_move The number ofsteps to move the motor
- * @param speed Max speed in 0.01*rad/sec 
+ * @param speed Max speed in 0.01*rad/sec
  * @param accel [optional] Acceleration in 0.01*rad/sec^2
  * @param decel [optional] Deceleration in 0.01*rad/sec^2
  */
-void FirmataStepper::setStepsToMove(long steps_to_move, int speed, int accel, int decel) {
+void FirmataStepper::setStepsToMove(long steps_to_move, int speed, int accel, int decel)
+{
   unsigned long maxStepLimit;
   unsigned long accelerationLimit;
 
   this->step_number = 0;
   this->lastAccelDelay = 0;
   this->stepCount = 0;
-  this->rest = 0;  
+  this->rest = 0;
 
-  if (steps_to_move < 0) {
+  if (steps_to_move < 0)
+  {
     this->direction = FirmataStepper::CCW;
     steps_to_move = -steps_to_move;
   }
-  else {
+  else
+  {
     this->direction = FirmataStepper::CW;
   }
 
@@ -140,7 +158,8 @@ void FirmataStepper::setStepsToMove(long steps_to_move, int speed, int accel, in
 
   // if acceleration or deceleration are not defined
   // start in RUN state and do no decelerate
-  if (accel == 0 || decel == 0) {
+  if (accel == 0 || decel == 0)
+  {
     this->step_delay = this->min_delay;
 
     this->decel_start = steps_to_move;
@@ -152,7 +171,8 @@ void FirmataStepper::setStepsToMove(long steps_to_move, int speed, int accel, in
   }
 
   // if only moving 1 step
-  if (steps_to_move == 1) {
+  if (steps_to_move == 1)
+  {
 
     // move one step
     this->accel_count = -1;
@@ -161,53 +181,61 @@ void FirmataStepper::setStepsToMove(long steps_to_move, int speed, int accel, in
     this->step_delay = this->min_delay;
     this->running = true;
   }
-  else if (steps_to_move != 0) {
+  else if (steps_to_move != 0)
+  {
     // set initial step delay
     // step_delay = 1/tt * sqrt(2*alpha/accel)
     // step_delay = ( tfreq*0.676/100 )*100 * sqrt( (2*alpha*10000000000) / (accel*100) )/10000
-    this->step_delay = (long)((T1_FREQ_148 * sqrt(alpha_x2/accel)) * 1000);   
+    this->step_delay = (long)((T1_FREQ_148 * sqrt(alpha_x2 / accel)) * 1000);
 
     // find out after how many steps does the speed hit the max speed limit.
     // maxSpeedLimit = speed^2 / (2*alpha*accel)
-    maxStepLimit = (long)speed*speed/(long)(((long)this->ax20000*accel)/100);
+    maxStepLimit = (long)speed * speed / (long)(((long)this->ax20000 * accel) / 100);
 
     // if we hit max spped limit before 0.5 step it will round to 0.
     // but in practice we need to move at least 1 step to get any speed at all.
-    if (maxStepLimit == 0) {
+    if (maxStepLimit == 0)
+    {
       maxStepLimit = 1;
-    }  
+    }
 
     // find out after how many steps we must start deceleration.
     // n1 = (n1+n2)decel / (accel + decel)
-    accelerationLimit = (long)((steps_to_move*decel) / (accel+decel));
+    accelerationLimit = (long)((steps_to_move * decel) / (accel + decel));
 
     // we must accelerate at least 1 step before we can start deceleration
-    if (accelerationLimit == 0) {
+    if (accelerationLimit == 0)
+    {
       accelerationLimit = 1;
-    }  
+    }
 
     // use the limit we hit first to calc decel
-    if (accelerationLimit <= maxStepLimit) {
+    if (accelerationLimit <= maxStepLimit)
+    {
       this->decel_val = accelerationLimit - steps_to_move;
     }
-    else {
-      this->decel_val = -(long)(maxStepLimit*accel)/decel;
+    else
+    {
+      this->decel_val = -(long)(maxStepLimit * accel) / decel;
     }
 
     // we must decelerate at least 1 step to stop
-    if(this->decel_val == 0) {
+    if (this->decel_val == 0)
+    {
       this->decel_val = -1;
-    }    
+    }
 
     // find step to start deceleration
     this->decel_start = steps_to_move + this->decel_val;
 
     // if the max spped is so low that we don't need to go via acceleration state.
-    if (this->step_delay <= this->min_delay) {
+    if (this->step_delay <= this->min_delay)
+    {
       this->step_delay = this->min_delay;
       this->run_state = FirmataStepper::RUN;
     }
-    else {
+    else
+    {
       this->run_state = FirmataStepper::ACCEL;
     }
 
@@ -218,80 +246,89 @@ void FirmataStepper::setStepsToMove(long steps_to_move, int speed, int accel, in
 }
 
 
-bool FirmataStepper::update() {
+bool FirmataStepper::update()
+{
   bool done = false;
   long newStepDelay;
 
   unsigned long curTimeVal = micros();
   long timeDiff = curTimeVal - this->last_step_time;
 
-  if (this->running == true && timeDiff >= this->step_delay) {
+  if (this->running == true && timeDiff >= this->step_delay)
+  {
 
     this->last_step_time = curTimeVal;
 
-    switch(this->run_state) {
-      case FirmataStepper::STOP:
-        this->stepCount = 0;
-        this->rest = 0;    
-        if (this->running) {
-          done = true;
-        }
-        this->running = false;
+    switch (this->run_state)
+    {
+    case FirmataStepper::STOP:
+      this->stepCount = 0;
+      this->rest = 0;
+      if (this->running)
+      {
+        done = true;
+      }
+      this->running = false;
       break;
 
-      case FirmataStepper::ACCEL:
-        updateStepPosition();
-        this->stepCount++;
-        this->accel_count++;
-        newStepDelay = this->step_delay - (((2 * (long)this->step_delay) + this->rest)/(4 * this->accel_count + 1));
-        this->rest = ((2 * (long)this->step_delay)+this->rest)%(4 * this->accel_count + 1);
+    case FirmataStepper::ACCEL:
+      updateStepPosition();
+      this->stepCount++;
+      this->accel_count++;
+      newStepDelay = this->step_delay - (((2 * (long)this->step_delay) + this->rest) / (4 * this->accel_count + 1));
+      this->rest = ((2 * (long)this->step_delay) + this->rest) % (4 * this->accel_count + 1);
 
-        // check if we should start deceleration
-        if (this->stepCount >= this->decel_start) {
-          this->accel_count = this->decel_val;
-          this->run_state = FirmataStepper::DECEL;
-          this->rest = 0;
-        }
-        // check if we hit max speed
-        else if (newStepDelay <= this->min_delay) {
-          this->lastAccelDelay = newStepDelay;
-          newStepDelay = this->min_delay;
-          this->rest = 0;
-          this->run_state = FirmataStepper::RUN;
-        }
-      break;
-
-      case FirmataStepper::RUN:
-        updateStepPosition();
-        this->stepCount++;
+      // check if we should start deceleration
+      if (this->stepCount >= this->decel_start)
+      {
+        this->accel_count = this->decel_val;
+        this->run_state = FirmataStepper::DECEL;
+        this->rest = 0;
+      }
+      // check if we hit max speed
+      else if (newStepDelay <= this->min_delay)
+      {
+        this->lastAccelDelay = newStepDelay;
         newStepDelay = this->min_delay;
-
-        // if no accel or decel was specified, go directly to STOP state
-        if (stepCount >= this->steps_to_move) {
-          this->run_state = FirmataStepper::STOP;
-        }
-        // check if we should start deceleration
-        else if (this->stepCount >= this->decel_start) {
-          this->accel_count = this->decel_val;
-          // start deceleration with same delay that accel ended with
-          newStepDelay = this->lastAccelDelay;
-          this->run_state = FirmataStepper::DECEL;
-        }
+        this->rest = 0;
+        this->run_state = FirmataStepper::RUN;
+      }
       break;
 
-      case FirmataStepper::DECEL:
-        updateStepPosition();
-        this->stepCount++;
-        this->accel_count++;  
+    case FirmataStepper::RUN:
+      updateStepPosition();
+      this->stepCount++;
+      newStepDelay = this->min_delay;
 
-        newStepDelay = this->step_delay - (((2 * (long)this->step_delay) + this->rest)/(4 * this->accel_count + 1));
-        this->rest = ((2 * (long)this->step_delay)+this->rest)%(4 * this->accel_count + 1);
+      // if no accel or decel was specified, go directly to STOP state
+      if (stepCount >= this->steps_to_move)
+      {
+        this->run_state = FirmataStepper::STOP;
+      }
+      // check if we should start deceleration
+      else if (this->stepCount >= this->decel_start)
+      {
+        this->accel_count = this->decel_val;
+        // start deceleration with same delay that accel ended with
+        newStepDelay = this->lastAccelDelay;
+        this->run_state = FirmataStepper::DECEL;
+      }
+      break;
 
-        if (newStepDelay < 0) newStepDelay = -newStepDelay;
-        // check if we ar at the last step
-        if (this->accel_count >= 0) {
-          this->run_state = FirmataStepper::STOP;
-        }
+    case FirmataStepper::DECEL:
+      updateStepPosition();
+      this->stepCount++;
+      this->accel_count++;
+
+      newStepDelay = this->step_delay - (((2 * (long)this->step_delay) + this->rest) / (4 * this->accel_count + 1));
+      this->rest = ((2 * (long)this->step_delay) + this->rest) % (4 * this->accel_count + 1);
+
+      if (newStepDelay < 0) newStepDelay = -newStepDelay;
+      // check if we ar at the last step
+      if (this->accel_count >= 0)
+      {
+        this->run_state = FirmataStepper::STOP;
+      }
 
       break;
     }
@@ -308,16 +345,22 @@ bool FirmataStepper::update() {
  * Update the step position.
  * @private
  */
-void FirmataStepper::updateStepPosition() {
+void FirmataStepper::updateStepPosition()
+{
   // increment or decrement the step number,
   // depending on direction:
-  if (this->direction == FirmataStepper::CW) {
+  if (this->direction == FirmataStepper::CW)
+  {
     this->step_number++;
-    if (this->step_number >= this->steps_per_rev) {
+    if (this->step_number >= this->steps_per_rev)
+    {
       this->step_number = 0;
     }
-  } else {
-    if (this->step_number <= 0) {
+  }
+  else
+  {
+    if (this->step_number <= 0)
+    {
       this->step_number = this->steps_per_rev;
     }
     this->step_number--;
@@ -333,65 +376,74 @@ void FirmataStepper::updateStepPosition() {
  * the 2 or 4 step sequence.
  * @param direction The direction of rotation
  */
-void FirmataStepper::stepMotor(byte step_num, byte direction) {
-  if (this->interface == FirmataStepper::DRIVER) {
+void FirmataStepper::stepMotor(byte step_num, byte direction)
+{
+  if (this->interface == FirmataStepper::DRIVER)
+  {
     digitalWrite(dir_pin, direction);
-	  delayMicroseconds(1);
-	  digitalWrite(step_pin, LOW);
-    delayMicroseconds(1);
-	  digitalWrite(step_pin, HIGH);
-  } else if (this->interface == FirmataStepper::TWO_WIRE) {
-    switch (step_num) {
-      case 0: /* 01 */
+    delayMicroseconds(this->stepDelay);
+    digitalWrite(step_pin, LOW);
+    delayMicroseconds(this->stepDelay);
+    digitalWrite(step_pin, HIGH);
+  }
+  else if (this->interface == FirmataStepper::TWO_WIRE)
+  {
+    switch (step_num)
+    {
+    case 0: /* 01 */
       digitalWrite(motor_pin_1, LOW);
       digitalWrite(motor_pin_2, HIGH);
       break;
-      case 1: /* 11 */
+    case 1: /* 11 */
       digitalWrite(motor_pin_1, HIGH);
       digitalWrite(motor_pin_2, HIGH);
       break;
-      case 2: /* 10 */
+    case 2: /* 10 */
       digitalWrite(motor_pin_1, HIGH);
       digitalWrite(motor_pin_2, LOW);
       break;
-      case 3: /* 00 */
+    case 3: /* 00 */
       digitalWrite(motor_pin_1, LOW);
       digitalWrite(motor_pin_2, LOW);
       break;
-    } 
-  } else if (this->interface == FirmataStepper::FOUR_WIRE) {
-    switch (step_num) {
-      case 0:    // 1010
+    }
+  }
+  else if (this->interface == FirmataStepper::FOUR_WIRE)
+  {
+    switch (step_num)
+    {
+    case 0:    // 1010
       digitalWrite(motor_pin_1, HIGH);
       digitalWrite(motor_pin_2, LOW);
       digitalWrite(motor_pin_3, HIGH);
       digitalWrite(motor_pin_4, LOW);
       break;
-      case 1:    // 0110
+    case 1:    // 0110
       digitalWrite(motor_pin_1, LOW);
       digitalWrite(motor_pin_2, HIGH);
       digitalWrite(motor_pin_3, HIGH);
       digitalWrite(motor_pin_4, LOW);
       break;
-      case 2:    //0101
+    case 2:    //0101
       digitalWrite(motor_pin_1, LOW);
       digitalWrite(motor_pin_2, HIGH);
       digitalWrite(motor_pin_3, LOW);
       digitalWrite(motor_pin_4, HIGH);
       break;
-      case 3:    //1001
+    case 3:    //1001
       digitalWrite(motor_pin_1, HIGH);
       digitalWrite(motor_pin_2, LOW);
       digitalWrite(motor_pin_3, LOW);
       digitalWrite(motor_pin_4, HIGH);
       break;
-    }     
+    }
   }
 }
 
 /**
  * @return The version number of this library.
  */
-byte FirmataStepper::version(void) {
-  return 1;
+byte FirmataStepper::version(void)
+{
+  return 2;
 }

--- a/utility/FirmataStepper.h
+++ b/utility/FirmataStepper.h
@@ -1,17 +1,17 @@
 /*
   FirmataStepper is a simple non-blocking stepper motor library
   for 2 and 4 wire bipolar and unipolar stepper motor drive circuits
-  as well as EasyDriver (http://schmalzhaus.com/EasyDriver/) and 
+  as well as EasyDriver (http://schmalzhaus.com/EasyDriver/) and
   other step + direction drive circuits.
 
   FirmataStepper (0.1) by Jeff Hoefs
-  
+
   EasyDriver support based on modifications by Chris Coleman
 
   Acceleration / Deceleration algorithms and code based on:
   app note: http://www.atmel.com/dyn/resources/prod_documents/doc8017.pdf
   source code: http://www.atmel.com/dyn/resources/prod_documents/AVR446.zip
-  
+
   stepMotor function based on Stepper.cpp Stepper library for
   Wiring/Arduino created by Tom Igoe, Sebastian Gassner
   David Mellis and Noah Shibley.
@@ -19,11 +19,11 @@
   Relevant notes from Stepper.cpp:
 
   When wiring multiple stepper motors to a microcontroller,
-  you quickly run out of output pins, with each motor requiring 4 connections. 
+  you quickly run out of output pins, with each motor requiring 4 connections.
 
   By making use of the fact that at any time two of the four motor
   coils are the inverse  of the other two, the number of
-  control connections can be reduced from 4 to 2. 
+  control connections can be reduced from 4 to 2.
 
   A slightly modified circuit around a Darlington transistor array or an L293 H-bridge
   connects to only 2 microcontroler pins, inverts the signals received,
@@ -47,7 +47,7 @@
      3  1  0
      4  0  0
 
-  The circuits can be found at 
+  The circuits can be found at
   http://www.arduino.cc/en/Tutorial/Stepper
 */
 
@@ -66,34 +66,38 @@
 #define T1_FREQ_148 ((long)((T1_FREQ*0.676)/100)) // divided by 100 and scaled by 0.676
 
 // library interface description
-class FirmataStepper {
+class FirmataStepper
+{
 public:
   FirmataStepper(byte interface = FirmataStepper::DRIVER,
-                  int steps_per_rev = 200,
-                  byte pin1 = 2,
-                  byte pin2 = 3,
-                  byte pin3 = 3,
-                  byte pin4 = 4);
+                 int steps_per_rev = 200,
+                 byte pin1 = 2,
+                 byte pin2 = 3,
+                 byte pin3 = 4,
+                 byte pin4 = 5);
 
-  enum Interface {
+  enum Interface
+  {
     DRIVER = 1,
     TWO_WIRE = 2,
     FOUR_WIRE = 4
   };
 
-  enum RunState {
+  enum RunState
+  {
     STOP = 0,
     ACCEL = 1,
     DECEL = 2,
     RUN = 3
   };
 
-  enum Direction {
+  enum Direction
+  {
     CCW = 0,
     CW = 1
   };
 
-  void setStepsToMove(long steps_to_move, int speed, int accel=0, int decel=0);
+  void setStepsToMove(long steps_to_move, int speed, int accel = 0, int decel = 0);
 
   // update the stepper position
   bool update();
@@ -110,6 +114,7 @@ private:
   int steps_per_rev;      // number of steps to make one revolution
   long step_number;        // which step the motor is on
   long steps_to_move;   // total number of teps to move
+  byte stepDelay;       // delay between steps (default = 1, increase for high current drivers)
 
   byte run_state;
   int accel_count;

--- a/utility/I2CFirmata.cpp
+++ b/utility/I2CFirmata.cpp
@@ -16,7 +16,7 @@
 
 #include <Firmata.h>
 #include <Wire.h>
-#include <I2CFirmata.h>
+#include "I2CFirmata.h"
 
 I2CFirmata::I2CFirmata()
 {

--- a/utility/I2CFirmata.cpp
+++ b/utility/I2CFirmata.cpp
@@ -113,8 +113,8 @@ void I2CFirmata::handleI2CRequest(byte argc, byte *argv)
 {
   byte mode;
   byte slaveAddress;
-  byte slaveRegister;
   byte data;
+  int slaveRegister;
   mode = argv[1] & I2C_READ_WRITE_MODE_MASK;
   if (argv[1] & I2C_10BIT_ADDRESS_MODE_MASK) {
     Firmata.sendString("10-bit addressing not supported");
@@ -157,10 +157,20 @@ void I2CFirmata::handleI2CRequest(byte argc, byte *argv)
       Firmata.sendString("too many queries");
       break;
     }
+    if (argc == 6) {
+      // a slave register is specified
+      slaveRegister = argv[2] + (argv[3] << 7);
+      data = argv[4] + (argv[5] << 7);  // bytes to read
+    }
+    else {
+      // a slave register is NOT specified
+      slaveRegister = (int)REGISTER_NOT_SPECIFIED;
+      data = argv[2] + (argv[3] << 7);  // bytes to read
+    }
     queryIndex++;
     query[queryIndex].addr = slaveAddress;
-    query[queryIndex].reg = argv[2] + (argv[3] << 7);
-    query[queryIndex].bytes = argv[4] + (argv[5] << 7);
+    query[queryIndex].reg = slaveRegister;
+    query[queryIndex].bytes = data;
     break;
   case I2C_STOP_READING:
     byte queryIndexToSkip;

--- a/utility/I2CFirmata.h
+++ b/utility/I2CFirmata.h
@@ -18,8 +18,8 @@
 #define I2CFirmata_h
 
 #include <Firmata.h>
-#include <utility/FirmataFeature.h>
-#include <utility/FirmataReporting.h>
+#include "FirmataFeature.h"
+#include "FirmataReporting.h"
 
 // move the following defines to Firmata.h?
 #define I2C_WRITE B00000000

--- a/utility/I2CFirmata.h
+++ b/utility/I2CFirmata.h
@@ -36,7 +36,7 @@
 /* i2c data */
 struct i2c_device_info {
   byte addr;
-  byte reg;
+  int reg;
   byte bytes;
 };
 

--- a/utility/OneWireFirmata.cpp
+++ b/utility/OneWireFirmata.cpp
@@ -11,8 +11,8 @@
 */
 
 #include <Firmata.h>
-#include <OneWireFirmata.h>
-#include <Encoder7Bit.h>
+#include "OneWireFirmata.h"
+#include "Encoder7Bit.h"
 
 boolean OneWireFirmata::handlePinMode(byte pin, int mode)
 {

--- a/utility/OneWireFirmata.h
+++ b/utility/OneWireFirmata.h
@@ -15,7 +15,7 @@
 
 #include "OneWire.h"
 #include <Firmata.h>
-#include <utility/FirmataFeature.h>
+#include "FirmataFeature.h"
 
 //subcommands:
 #define ONEWIRE_SEARCH_REQUEST 0x40

--- a/utility/ServoFirmata.cpp
+++ b/utility/ServoFirmata.cpp
@@ -16,7 +16,7 @@
 
 #include <Servo.h>
 #include <Firmata.h>
-#include <ServoFirmata.h>
+#include "ServoFirmata.h"
 
 ServoFirmata *ServoInstance;
 

--- a/utility/ServoFirmata.h
+++ b/utility/ServoFirmata.h
@@ -19,7 +19,7 @@
 
 #include <Servo.h>
 #include <Firmata.h>
-#include <utility/FirmataFeature.h>
+#include "FirmataFeature.h"
 
 void servoAnalogWrite(byte pin, int value);
 

--- a/utility/StepperFirmata.cpp
+++ b/utility/StepperFirmata.cpp
@@ -30,8 +30,8 @@
  * TODO: use Program Control to load stored profiles from EEPROM
  */
 
-#include <StepperFirmata.h>
-#include <FirmataStepper.h>
+#include "StepperFirmata.h"
+#include "FirmataStepper.h"
 #include <Firmata.h>
 
 boolean StepperFirmata::handlePinMode(byte pin, int mode)

--- a/utility/StepperFirmata.h
+++ b/utility/StepperFirmata.h
@@ -35,7 +35,7 @@
 
 #include "FirmataStepper.h"
 #include <Firmata.h>
-#include <utility/FirmataFeature.h>
+#include "FirmataFeature.h"
 
 #define MAX_STEPPERS 6 // arbitrary value... may need to adjust
 #define STEPPER_CONFIG 0


### PR DESCRIPTION
After this merge lets stop using `configurable_dev`. Contributors should instead create a topic branch off of the `configurable` branch. If collaboration on a feature is needed we can create a common topic feature branch if necessary.

This pull request includes a [bugfix for I2C_READ_CONTINUOUSLY](https://github.com/firmata/arduino/commit/e28b07901aa4cae58f10200f9af0f64c940c3413) and a number of small formatting tweaks. It also adds the ability to change the stepDelay for Stepper from 1 microsecond to 2 microseconds to support some high current stepper drivers. The version has been bumped to 2.6.1.

I'm using the [sublime text astyle plugin](https://github.com/timonwong/SublimeAStyleFormatter) for formatting. I've only run it on Firmata.cpp, Firmata.h and Boards.h so far. I'll update formatting all files in an upcoming commit. The only change I've made in the astyle default options is changing spacing from 4 to 2 spaces (no tabs).

This pull request also changes all of the includes for local files (in the utility directory) to use double quotes rather than brackets. I was having issues with the brackets (unless changing all to `<utility/filename.h>`) in clean versions of Arduino. I've tested the updated version in Arduino 1.0.5, 1.0.6, 1.5.7 and 1.5.8 both with the bundled versions (run [release.sh](https://github.com/firmata/arduino/blob/configurable_dev/release.sh) and copy the Firmata file, overwriting the core Firmata library) as well as copying the raw directory structure from this repo into the core Firmata library directory. Was able to compile without issue in all tested versions of the IDE.