### PR TITLE
Enable servo to be attached to pins higher than 15

### DIFF
--- a/Firmata.cpp
+++ b/Firmata.cpp
@@ -1,5 +1,5 @@
 /*
-  Firmata.cpp - Firmata library v2.6.0 - 2014-03-08
+  Firmata.cpp - Firmata library v2.6.1 - 2014-08-17
   Copyright (C) 2006-2008 Hans-Christoph Steiner.  All rights reserved.
  
   This library is free software; you can redistribute it and/or

--- a/Firmata.cpp
+++ b/Firmata.cpp
@@ -433,12 +433,20 @@ byte FirmataClass::getPinMode(byte pin)
 
 void FirmataClass::setPinMode(byte pin, byte config)
 {
-  if (pinConfig[pin]==IGNORE)
+  if (pinConfig[pin] == IGNORE)
+    return;
+  setPinConfig(pin, config);
+  if (currentPinModeCallback)
+    (*currentPinModeCallback)(pin, config);
+}
+
+/* set pin config without calling the pin mode callback */
+void FirmataClass::setPinConfig(byte pin, byte config)
+{
+  if (pinConfig[pin] == IGNORE)
     return;
   pinState[pin] = 0;
   pinConfig[pin] = config;
-  if(currentPinModeCallback)
-    (*currentPinModeCallback)(pin, config);
 }
 
 /* access pin state */

--- a/Firmata.h
+++ b/Firmata.h
@@ -133,6 +133,7 @@ public:
 /* access pin config */
     byte getPinMode(byte pin);
     void setPinMode(byte pin, byte config);
+    void setPinConfig(byte pin, byte config);
 /* access pin state */
     int getPinState(byte pin);
     void setPinState(byte pin, int state);

--- a/Firmata.h
+++ b/Firmata.h
@@ -1,5 +1,5 @@
 /*
-  Firmata.h - Firmata library v2.6.0 - 2014-03-08
+  Firmata.h - Firmata library v2.6.1 - 2014-08-17
   Copyright (C) 2006-2008 Hans-Christoph Steiner.  All rights reserved.
  
   This library is free software; you can redistribute it and/or
@@ -21,7 +21,7 @@
  * installed firmware. */
 #define FIRMATA_MAJOR_VERSION   2 // for non-compatible changes
 #define FIRMATA_MINOR_VERSION   6 // for backwards compatible changes
-#define FIRMATA_BUGFIX_VERSION  0 // for bugfix releases
+#define FIRMATA_BUGFIX_VERSION  1 // for bugfix releases
 
 #define MAX_DATA_BYTES          64 // max number of data bytes in incoming messages
 

--- a/examples/ConfigurableFirmata/ConfigurableFirmata.ino
+++ b/examples/ConfigurableFirmata/ConfigurableFirmata.ino
@@ -13,7 +13,7 @@
   Copyright (C) 2006-2008 Hans-Christoph Steiner.  All rights reserved.
   Copyright (C) 2010-2011 Paul Stoffregen.  All rights reserved.
   Copyright (C) 2009 Shigeru Kobayashi.  All rights reserved.
-  Copyright (C) 2009-2013 Jeff Hoefs.  All rights reserved.
+  Copyright (C) 2009-2014 Jeff Hoefs.  All rights reserved.
   Copyright (C) 2013 Norbert Truchsess. All rights reserved.
   Copyright (C) 2014 Nicolas Panel. All rights reserved.
   
@@ -90,6 +90,10 @@ AnalogOutputFirmata analogOutput;
 #include <utility/ServoFirmata.h>
 ServoFirmata servo;
 
+#if defined ServoFirmata_h && ! defined AnalogOutputFirmata_h
+#error AnalogOutputFirmata must be included to use ServoFirmata
+#endif
+
 #include <Wire.h> //wouldn't load from I2CFirmata.h in Arduino1.0.3
 #include <utility/I2CFirmata.h>
 I2CFirmata i2c;
@@ -108,12 +112,6 @@ FirmataScheduler scheduler;
 
 #include <utility/EncoderFirmata.h>
 EncoderFirmata encoder;
-
-
-// dependencies. Do not comment out the following lines
-#if defined AnalogOutputFirmata_h || defined ServoFirmata_h
-#include <utility/AnalogWrite.h>
-#endif
 
 #if defined AnalogInputFirmata_h || defined I2CFirmata_h || defined EncoderFirmata_h
 #include <utility/FirmataReporting.h>
@@ -187,11 +185,6 @@ void setup()
   delay(1000);
 #endif
   Firmata.setFirmwareVersion(FIRMATA_MAJOR_VERSION, FIRMATA_MINOR_VERSION);
-
-#if defined AnalogOutputFirmata_h || defined ServoFirmata_h
-  /* analogWriteCallback is declared in AnalogWrite.h */
-  Firmata.attach(ANALOG_MESSAGE, analogWriteCallback);
-#endif
 
   #ifdef FirmataExt_h
 #ifdef DigitalInputFirmata_h

--- a/utility/AnalogInputFirmata.cpp
+++ b/utility/AnalogInputFirmata.cpp
@@ -3,7 +3,7 @@
   Copyright (C) 2006-2008 Hans-Christoph Steiner.  All rights reserved.
   Copyright (C) 2010-2011 Paul Stoffregen.  All rights reserved.
   Copyright (C) 2009 Shigeru Kobayashi.  All rights reserved.
-  Copyright (C) 2009-2011 Jeff Hoefs.  All rights reserved.
+  Copyright (C) 2009-2014 Jeff Hoefs.  All rights reserved.
   Copyright (C) 2013 Norbert Truchsess. All rights reserved.
 
   This library is free software; you can redistribute it and/or
@@ -77,17 +77,7 @@ void AnalogInputFirmata::handleCapability(byte pin)
 
 boolean AnalogInputFirmata::handleSysex(byte command, byte argc, byte* argv)
 {
-  if (command == EXTENDED_ANALOG) {
-    if (argc > 1) {
-      int val = argv[1];
-      if (argc > 2) val |= (argv[2] << 7);
-      if (argc > 3) val |= (argv[3] << 14);
-      analogWrite(argv[0], val);
-      return true;
-    }
-  } else {
-    return handleAnalogFirmataSysex(command, argc, argv);
-  }
+  return handleAnalogFirmataSysex(command, argc, argv);
 }
 
 void AnalogInputFirmata::reset()

--- a/utility/AnalogOutputFirmata.h
+++ b/utility/AnalogOutputFirmata.h
@@ -20,9 +20,13 @@
 #include <Firmata.h>
 #include <utility/FirmataFeature.h>
 
+void analogWriteCallback(byte pin, int value);
+
 class AnalogOutputFirmata:public FirmataFeature
 {
 public:
+  AnalogOutputFirmata();
+  void analogOutput(byte pin, int value);
   void handleCapability(byte pin);
   boolean handlePinMode(byte pin, int mode);
   boolean handleSysex(byte command, byte argc, byte* argv);

--- a/utility/AnalogWrite.h
+++ b/utility/AnalogWrite.h
@@ -3,7 +3,7 @@
   Copyright (C) 2006-2008 Hans-Christoph Steiner.  All rights reserved.
   Copyright (C) 2010-2011 Paul Stoffregen.  All rights reserved.
   Copyright (C) 2009 Shigeru Kobayashi.  All rights reserved.
-  Copyright (C) 2009-2011 Jeff Hoefs.  All rights reserved.
+  Copyright (C) 2009-2014 Jeff Hoefs.  All rights reserved.
   Copyright (C) 2013 Norbert Truchsess. All rights reserved.
 
   This library is free software; you can redistribute it and/or
@@ -23,6 +23,7 @@
 
 void analogWriteCallback(byte pin, int value)
 {
+  Firmata.sendString("analog write callback");
   if (pin < TOTAL_PINS) {
     switch(Firmata.getPinMode(pin)) {
 #ifdef ServoFirmata_h

--- a/utility/AnalogWrite.h
+++ b/utility/AnalogWrite.h
@@ -23,7 +23,6 @@
 
 void analogWriteCallback(byte pin, int value)
 {
-  Firmata.sendString("analog write callback");
   if (pin < TOTAL_PINS) {
     switch(Firmata.getPinMode(pin)) {
 #ifdef ServoFirmata_h

--- a/utility/AnalogWrite.h
+++ b/utility/AnalogWrite.h
@@ -27,9 +27,9 @@ void analogWriteCallback(byte pin, int value)
     switch(Firmata.getPinMode(pin)) {
 #ifdef ServoFirmata_h
     case SERVO:
-      if (IS_PIN_SERVO(pin)) {
-        servoAnalogWrite(pin,value);
-        Firmata.setPinState(pin,value);
+      if (IS_PIN_DIGITAL(pin)) {
+        servoAnalogWrite(pin, value);
+        Firmata.setPinState(pin, value);
       }
       break;
 #endif
@@ -37,7 +37,7 @@ void analogWriteCallback(byte pin, int value)
     case PWM:
       if (IS_PIN_PWM(pin)) {
         analogWrite(PIN_TO_PWM(pin), value);
-        Firmata.setPinState(pin,value);
+        Firmata.setPinState(pin, value);
       }
       break;
 #endif

--- a/utility/ServoFirmata.cpp
+++ b/utility/ServoFirmata.cpp
@@ -3,7 +3,7 @@
   Copyright (C) 2006-2008 Hans-Christoph Steiner.  All rights reserved.
   Copyright (C) 2010-2011 Paul Stoffregen.  All rights reserved.
   Copyright (C) 2009 Shigeru Kobayashi.  All rights reserved.
-  Copyright (C) 2009-2011 Jeff Hoefs.  All rights reserved.
+  Copyright (C) 2009-2014 Jeff Hoefs.  All rights reserved.
   Copyright (C) 2013 Norbert Truchsess. All rights reserved.
 
   This library is free software; you can redistribute it and/or
@@ -81,6 +81,15 @@ boolean ServoFirmata::handleSysex(byte command, byte argc, byte* argv)
       }
     }
   }
+  if (command == EXTENDED_ANALOG) {
+    if (argc > 1) {
+      int val = argv[1];
+      if (argc > 2) val |= (argv[2] << 7);
+      if (argc > 3) val |= (argv[3] << 14);
+      analogWrite(argv[0], val);
+      return true;
+    }
+  }  
   return false;
 }
 

--- a/utility/ServoFirmata.cpp
+++ b/utility/ServoFirmata.cpp
@@ -22,31 +22,37 @@ ServoFirmata *ServoInstance;
 
 void servoAnalogWrite(byte pin, int value)
 {
-  ServoInstance->analogWrite(pin,value);
+  ServoInstance->analogWrite(pin, value);
 }
 
 ServoFirmata::ServoFirmata()
 {
   ServoInstance = this;
+  for (byte pin = 0; pin < TOTAL_PINS; pin++) {
+    servoPinMap[pin] = 255;
+  }  
+  detachedServoCount = 0;
+  servoCount = 0;
 }
 
 boolean ServoFirmata::analogWrite(byte pin, int value)
 {
-  if (IS_PIN_SERVO(pin)) {
-    Servo *servo = servos[PIN_TO_SERVO(pin)];
-    if (servo)
-      servo->write(value);
+  if (IS_PIN_DIGITAL(pin) && servoPinMap[pin] != 255) {
+    servos[servoPinMap[pin]].write(value);
   }
 }
 
 boolean ServoFirmata::handlePinMode(byte pin, int mode)
 {
-  if (IS_PIN_SERVO(pin)) {
-    if (mode==SERVO) {
-      attach(pin,-1,-1);
+  if (IS_PIN_DIGITAL(pin)) {
+    if (mode == SERVO) {
+      Firmata.setPinConfig(pin, mode);
+      attach(pin, -1, -1);
       return true;
     } else {
-      detach(pin);
+      if (servoPinMap[pin] < MAX_SERVOS && servos[servoPinMap[pin]].attached()) {
+        detach(pin);
+      }
     }
   }
   return false;
@@ -54,7 +60,7 @@ boolean ServoFirmata::handlePinMode(byte pin, int mode)
 
 void ServoFirmata::handleCapability(byte pin)
 {
-  if (IS_PIN_SERVO(pin)) {
+  if (IS_PIN_DIGITAL(pin)) {
     Firmata.write(SERVO);
     Firmata.write(14); //14 bit resolution (Servo takes int as argument)
   }
@@ -66,11 +72,11 @@ boolean ServoFirmata::handleSysex(byte command, byte argc, byte* argv)
     if (argc > 4) {
       // these vars are here for clarity, they'll optimized away by the compiler
       byte pin = argv[0];
-      if (IS_PIN_SERVO(pin) && Firmata.getPinMode(pin)!=IGNORE) {
+      if (IS_PIN_DIGITAL(pin) && Firmata.getPinMode(pin)!=IGNORE) {
         int minPulse = argv[1] + (argv[2] << 7);
         int maxPulse = argv[3] + (argv[4] << 7);
-        Firmata.setPinMode(pin, SERVO);
         attach(pin, minPulse, maxPulse);
+        Firmata.setPinMode(pin, SERVO);
         return true;
       }
     }
@@ -80,35 +86,58 @@ boolean ServoFirmata::handleSysex(byte command, byte argc, byte* argv)
 
 void ServoFirmata::attach(byte pin, int minPulse, int maxPulse)
 {
-  Servo *servo = servos[PIN_TO_SERVO(pin)];
-  if (!servo) {
-    servo = new Servo();
-    servos[PIN_TO_SERVO(pin)] = servo;
+  if (servoCount >= MAX_SERVOS) {
+    Firmata.sendString("Max servos attached");
+    return;
   }
-  if (servo->attached())
-    servo->detach();
-  if (minPulse>=0 || maxPulse>=0)
-    servo->attach(PIN_TO_DIGITAL(pin),minPulse,maxPulse);
+ 
+  if (servoPinMap[pin] != 255 && servos[servoPinMap[pin]].attached())
+    servos[servoPinMap[pin]].detach();
+
+  // reuse indexes of detached servos until all have been reallocated
+  if (detachedServoCount > 0) {
+    servoPinMap[pin] = detachedServos[detachedServoCount - 1];
+    if (detachedServoCount > 0) detachedServoCount--;
+  } else {
+    servoPinMap[pin] = servoCount;
+    servoCount++;
+  }
+  if (minPulse >= 0 || maxPulse >= 0)
+    servos[servoPinMap[pin]].attach(PIN_TO_DIGITAL(pin), minPulse, maxPulse);
   else
-    servo->attach(PIN_TO_DIGITAL(pin));
+    servos[servoPinMap[pin]].attach(PIN_TO_DIGITAL(pin));
 }
 
 void ServoFirmata::detach(byte pin)
 {
-  Servo *servo = servos[PIN_TO_SERVO(pin)];
-  if (servo) {
-    if (servo->attached())
-      servo->detach();
-    free(servo);
-    servos[PIN_TO_SERVO(pin)]=NULL;
+  if (servoPinMap[pin] == 255)
+    return;
+  
+  if (servos[servoPinMap[pin]].attached()) {
+    servos[servoPinMap[pin]].detach();
+
+    // if we're detaching the last servo, decrement the count
+    // otherwise store the index of the detached servo
+    if (servoPinMap[pin] == servoCount && servoCount > 0) {
+      servoCount--;
+    } else if (servoCount > 0) {
+      // keep track of detached servos because we want to reuse their indexes
+      // before incrementing the count of attached servos
+      detachedServoCount++;
+      detachedServos[detachedServoCount - 1] = servoPinMap[pin];
+    }
   }
+
+  servoPinMap[pin] = 255;
 }
 
 void ServoFirmata::reset()
 {
-  for (byte pin=0;pin<TOTAL_PINS;pin++) {
-    if (IS_PIN_SERVO(pin)) {
+  for (byte pin = 0; pin < TOTAL_PINS; pin++) {
+    if (IS_PIN_DIGITAL(pin)) {
       detach(pin);
     }
   }
+  detachedServoCount = 0;
+  servoCount = 0;
 }

--- a/utility/ServoFirmata.cpp
+++ b/utility/ServoFirmata.cpp
@@ -81,15 +81,6 @@ boolean ServoFirmata::handleSysex(byte command, byte argc, byte* argv)
       }
     }
   }
-  if (command == EXTENDED_ANALOG) {
-    if (argc > 1) {
-      int val = argv[1];
-      if (argc > 2) val |= (argv[2] << 7);
-      if (argc > 3) val |= (argv[3] << 14);
-      analogWrite(argv[0], val);
-      return true;
-    }
-  }  
   return false;
 }
 

--- a/utility/ServoFirmata.h
+++ b/utility/ServoFirmata.h
@@ -3,7 +3,7 @@
   Copyright (C) 2006-2008 Hans-Christoph Steiner.  All rights reserved.
   Copyright (C) 2010-2011 Paul Stoffregen.  All rights reserved.
   Copyright (C) 2009 Shigeru Kobayashi.  All rights reserved.
-  Copyright (C) 2009-2011 Jeff Hoefs.  All rights reserved.
+  Copyright (C) 2009-2014 Jeff Hoefs.  All rights reserved.
   Copyright (C) 2013 Norbert Truchsess. All rights reserved.
 
   This library is free software; you can redistribute it and/or

--- a/utility/ServoFirmata.h
+++ b/utility/ServoFirmata.h
@@ -33,7 +33,11 @@ public:
   boolean handleSysex(byte command, byte argc, byte* argv);
   void reset();
 private:
-  Servo *servos[MAX_SERVOS];
+  Servo servos[MAX_SERVOS];
+  byte servoPinMap[TOTAL_PINS];
+  byte detachedServos[MAX_SERVOS];
+  byte detachedServoCount;
+  byte servoCount;
   void attach(byte pin, int minPulse, int maxPulse);
   void detach(byte pin);
 };


### PR DESCRIPTION
Reopening against configurable branch.
See https://github.com/firmata/arduino/pull/149 for additional comments.

There are a 3 big internal changes here to the servo functionality:

1. Memory for all servos is now allocated right away rather than dynamically allocating servo instances. This ensures the user will have enough memory if their intent is to use a ton of servos. It also enables servos to be detached and reattached without increasing the Servo instance count (since each time you instantiate a Servo a count is incremented in the Servo library, but this count is never decremented).

2. The way servos are mapped to pins was changed to allow servos to be used on a wider range of pins. This change has also been made in StandardFirmata (in the dev branch... I still need to copy those changes to StandardFirmata in configurable_dev).

3. There was a bug in configurable firmata in which servos could not be attached on pins higher than 15 for any board. This was not an easy issue to fix and my solution required coupling AnalogOutputFirmata and ServoFirmata. I'd like to find a more elegant solution here if possible.

@ntruchsess please take a look at this commit in particular if you have some time: https://github.com/soundanalogous/arduino-1/commit/5ae28d43acbad785ac5486f85514b59433ff8261 and let me know if you have any other ideas. The root of the issue was that the EXTENDED_ANALOG command (I moved it from AnalogInputFirmata to AnalogOutputFirmata) was calling analogWrite when it really needed to be calling analogWriteCallback (defined in AnalogWrite.h but now moved to AnalogOutputFirmata). This was preventing extended analog messages on servo pins from being set.

I think the better long term solution is going to be creating a new Sysex version of ServoFirmata and deprecating the old (current) version that used AnalogOutput to set the value.