### PR TITLE
Adds Tone functionality

### DIFF
--- a/Firmata.h
+++ b/Firmata.h
@@ -41,6 +41,7 @@
 
 // extended command set using sysex (0-127/0x00-0x7F)
 /* 0x00-0x0F reserved for user-defined commands */
+#define TONE_DATA               0x5F // send a tone or noTone command 
 #define SERVO_CONFIG            0x70 // set max angle, minPulse, maxPulse, freq
 #define STRING_DATA             0x71 // a string message with 14-bits per char
 #define STEPPER_DATA            0x72 // control a stepper motor
@@ -77,8 +78,9 @@
 #define I2C                     0x06 // pin included in I2C setup
 #define ONEWIRE                 0x07 // pin configured for 1-wire
 #define STEPPER                 0x08 // pin configured for stepper motor
+#define TONE                    0x09 // pin configured for tone function
 #define IGNORE                  0x7F // pin configured to be ignored by digitalWrite and capabilityResponse
-#define TOTAL_PIN_MODES         10
+#define TOTAL_PIN_MODES         11
 
 extern "C" {
 // callback function types

--- a/examples/ConfigurableFirmata/ConfigurableFirmata.ino
+++ b/examples/ConfigurableFirmata/ConfigurableFirmata.ino
@@ -99,6 +99,9 @@ OneWireFirmata oneWire;
 #include <utility/StepperFirmata.h>
 StepperFirmata stepper;
 
+#include <utility/ToneFirmata.h>
+ToneFirmata toneFirmata;
+
 #include <utility/FirmataExt.h>
 FirmataExt firmataExt;
 
@@ -214,6 +217,9 @@ void setup()
 #ifdef StepperFirmata_h
   firmataExt.addFeature(stepper);
 #endif
+#ifdef ToneFirmata_h
+  firmataExt.addFeature(toneFirmata);
+#endif  
 #ifdef FirmataReporting_h
   firmataExt.addFeature(reporting);
 #endif

--- a/utility/ToneFirmata.cpp
+++ b/utility/ToneFirmata.cpp
@@ -1,0 +1,102 @@
+/*
+ * Firmata is a generic protocol for communicating with microcontrollers
+ * from software on a host computer. It is intended to work with
+ * any host computer software package.
+ *
+ * To download a host software package, please clink on the following link
+ * to open the download page in your default browser.
+ *
+ * http://firmata.org/wiki/Download
+ */
+
+/*
+  Copyright (C) 2006-2008 Hans-Christoph Steiner.  All rights reserved.
+  Copyright (C) 2010-2011 Paul Stoffregen.  All rights reserved.
+  Copyright (C) 2009 Shigeru Kobayashi.  All rights reserved.
+  Copyright (C) 2009-2013 Jeff Hoefs.  All rights reserved.
+  Copyright (C) 2013 Norbert Truchsess. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  See file LICENSE.txt for further informations on licensing terms.
+
+  formatted using the GNU C formatting and indenting
+*/
+
+#include <ToneFirmata.h>
+#include <Firmata.h>
+
+boolean ToneFirmata::handlePinMode(byte pin, int mode)
+{
+  if (mode == TONE) {
+    if (IS_PIN_DIGITAL(pin)) {
+      //digitalWrite(PIN_TO_DIGITAL(pin), LOW); // disable PWM
+      //pinMode(PIN_TO_DIGITAL(pin), OUTPUT);
+      return true;
+    }
+  }
+  return false;
+}
+
+void ToneFirmata::handleCapability(byte pin)
+{
+  if (IS_PIN_DIGITAL(pin)) {
+    Firmata.write(TONE);
+    Firmata.write(14); // 14 bit frequency value
+  }
+}
+
+/*==============================================================================
+ * SYSEX-BASED commands
+ *============================================================================*/
+
+// TO DO: make duration optional?
+// if duration is option, then noTone would need to be called to end tone
+boolean ToneFirmata::handleSysex(byte command, byte argc, byte *argv)
+{
+  byte toneCommand, pin;
+  int frequency, duration;
+
+  if (command == TONE_DATA) {
+
+    toneCommand = argv[0];
+    pin = argv[1];
+
+    if (Firmata.getPinMode(pin) != TONE) {
+      if (IS_PIN_DIGITAL(pin) && Firmata.getPinMode(pin) != IGNORE) {
+        Firmata.setPinMode(pin, TONE);
+      }      
+    }
+
+    if (toneCommand == TONE_TONE) {
+      frequency = argv[2] + (argv[3] << 7);
+      // duration is currently limited to 16,383 ms
+      duration = argv[4] + (argv[5] << 7);
+      tone(pin, frequency, duration);
+    }
+    else if (toneCommand == TONE_NO_TONE) {
+      noTone(pin);
+    }
+    return true;
+
+  }
+  return false;
+}
+
+/*==============================================================================
+ * SETUP()
+ *============================================================================*/
+
+void ToneFirmata::reset()
+{
+  // currently reset is called after all pins have been reset to default so
+  // the following won't work until this is resolved (if necessary)
+  // for (int i=0; i < TOTAL_PINS; i++) {
+  //   if (Firmata.getPinMode(i) == TONE) {
+  //     noTone(i);
+  //   }
+  // }
+}

--- a/utility/ToneFirmata.h
+++ b/utility/ToneFirmata.h
@@ -1,0 +1,47 @@
+/*
+ * Firmata is a generic protocol for communicating with microcontrollers
+ * from software on a host computer. It is intended to work with
+ * any host computer software package.
+ *
+ * To download a host software package, please clink on the following link
+ * to open the download page in your default browser.
+ *
+ * http://firmata.org/wiki/Download
+ */
+
+/*
+  Copyright (C) 2006-2008 Hans-Christoph Steiner.  All rights reserved.
+  Copyright (C) 2010-2011 Paul Stoffregen.  All rights reserved.
+  Copyright (C) 2009 Shigeru Kobayashi.  All rights reserved.
+  Copyright (C) 2009-2013 Jeff Hoefs.  All rights reserved.
+  Copyright (C) 2013 Norbert Truchsess. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  See file LICENSE.txt for further informations on licensing terms.
+
+  formatted using the GNU C formatting and indenting
+*/
+
+#ifndef ToneFirmata_h
+#define ToneFirmata_h
+
+#include <Firmata.h>
+#include <utility/FirmataFeature.h>
+
+#define TONE_TONE     0x00
+#define TONE_NO_TONE  0x01
+
+class ToneFirmata:public FirmataFeature
+{
+public:
+  boolean handlePinMode(byte pin, int mode);
+  void handleCapability(byte pin);
+  boolean handleSysex(byte command, byte argc, byte *argv);
+  void reset();
+};
+
+#endif


### PR DESCRIPTION
Reopening against configurable branch.

Still have some work to do here, but submitting this now for review.

To do: 
- Make duration optional
- If duration is optional, make sure `noTone()` is called during a systemReset

Note: It would be helpful if the call to firmataExt.reset() in the systemResetCall function of ConfigurableFirmata was before the pins are reset to their default modes. This would enable the reset function of any particular feature class to perform any cleanup based on a specific pin mode. For example, ensuring that `noTone()` is called for any `TONE` pins. I'm not sure if this has any negative effects yet.