### PR TITLE
Fixed off-by-one bug in setFirmwareNameAndVersion() where we were writin...

### DIFF
--- a/Firmata.cpp
+++ b/Firmata.cpp
@@ -146,7 +146,7 @@ void FirmataClass::setFirmwareNameAndVersion(const char *name, byte major, byte 
   // in case anyone calls setFirmwareNameAndVersion more than once
   free(firmwareVersionVector);
 
-  firmwareVersionVector = (byte *) malloc(firmwareVersionCount);
+  firmwareVersionVector = (byte *) malloc(firmwareVersionCount+1);
   firmwareVersionVector[firmwareVersionCount] = 0;
   firmwareVersionVector[0] = major;
   firmwareVersionVector[1] = minor;


### PR DESCRIPTION
...g a zero terminator past the end of the block we'd gotten from malloc().

Since the next line writes a zero to the firmwareVersionCount byte of firmwareVersionVector, we need to ask for one more than that bytes from malloc() so that we have enough space. Without the "+1", you write past the end of the array, which doesn't play nice with some malloc implementations (PIC32/chipKIT being one).