### PR TITLE
prevent analog reporting during system reset

### DIFF
--- a/examples/StandardFirmata/StandardFirmata.ino
+++ b/examples/StandardFirmata/StandardFirmata.ino
@@ -77,6 +77,8 @@ struct i2c_device_info {
 /* for i2c read continuous more */
 i2c_device_info query[MAX_QUERIES];
 
+boolean isResetting = false;
+
 byte i2cRxData[32];
 boolean isI2CEnabled = false;
 signed char queryIndex = -1;
@@ -349,10 +351,14 @@ void reportAnalogCallback(byte analogPin, int value)
       analogInputsToReport = analogInputsToReport & ~ (1 << analogPin);
     } else {
       analogInputsToReport = analogInputsToReport | (1 << analogPin);
-      // Send pin value immediately. This is helpful when connected via
-      // ethernet, wi-fi or bluetooth so pin states can be known upon
-      // reconnecting.
-      Firmata.sendAnalog(analogPin, analogRead(analogPin));
+      // prevent during system reset or all analog pin values will be reported
+      // which may report noise for unconnected analog pins
+      if (!isResetting) {
+        // Send pin value immediately. This is helpful when connected via
+        // ethernet, wi-fi or bluetooth so pin states can be known upon
+        // reconnecting.
+        Firmata.sendAnalog(analogPin, analogRead(analogPin));
+      }
     }
   }
   // TODO: save status to EEPROM here, if changed
@@ -610,6 +616,7 @@ void disableI2CPins() {
 
 void systemResetCallback()
 {
+  isResetting = true;
   // initialize a defalt state
   // TODO: option to load config from EEPROM instead of default
   if (isI2CEnabled) {
@@ -650,6 +657,7 @@ void systemResetCallback()
     outputPort(i, readPort(i, portConfigInputs[i]), true);
   }
   */
+  isResetting = false;
 }
 
 void setup()

--- a/extras/revisions.txt
+++ b/extras/revisions.txt
@@ -3,6 +3,9 @@ FIRMATA 2.4.1 - Feb 7, 2015
 [core library]
 * Fixed off-by-one bug in setFirmwareNameAndVersion (Brian Schmalz)
 
+[StandardFirmata]
+* Prevent analog values from being reported during system reset
+
 FIRMATA 2.4.0 - Dec 21, 2014
 
 Changes from 2.3.6 to 2.4 that may impact existing Firmata client implementations:


### PR DESCRIPTION
Fixes an issue where analog values were being reporting every time system reset was called.