### PR TITLE
prevent analog reporting from system reset function

### DIFF
--- a/Firmata.cpp
+++ b/Firmata.cpp
@@ -294,6 +294,11 @@ boolean FirmataClass::isParsingMessage(void)
 {
   return (waitForData > 0 || parsingSysex);
 }
+
+boolean FirmataClass::isResetting(void)
+{
+  return resetting;
+}
 //------------------------------------------------------------------------------
 // Serial Send Handling
 
@@ -479,6 +484,7 @@ void FirmataClass::setPinState(byte pin, int state)
 // resets the system state upon a SYSTEM_RESET message from the host software
 void FirmataClass::systemReset(void)
 {
+  resetting = true;
   byte i;
 
   waitForData = 0; // this flag says the next serial input will be data
@@ -494,6 +500,8 @@ void FirmataClass::systemReset(void)
 
   if (currentSystemResetCallback)
     (*currentSystemResetCallback)();
+
+  resetting = false;
 }
 
 

--- a/Firmata.h
+++ b/Firmata.h
@@ -113,6 +113,7 @@ class FirmataClass
     void processInput(void);
     void parse(unsigned char value);
     boolean isParsingMessage(void);
+    boolean isResetting(void);
     /* serial send handling */
     void sendAnalog(byte pin, int value);
     void sendDigital(byte pin, int value); // TODO implement this
@@ -154,6 +155,8 @@ class FirmataClass
     /* pins configuration */
     byte pinConfig[TOTAL_PINS];         // configuration of every pin
     int pinState[TOTAL_PINS];           // any value that has been written
+
+    boolean resetting;
 
     /* callback functions */
     callbackFunction currentAnalogCallback;

--- a/examples/StandardFirmata/StandardFirmata.ino
+++ b/examples/StandardFirmata/StandardFirmata.ino
@@ -77,8 +77,6 @@ struct i2c_device_info {
 /* for i2c read continuous more */
 i2c_device_info query[MAX_QUERIES];
 
-boolean isResetting = false;
-
 byte i2cRxData[32];
 boolean isI2CEnabled = false;
 signed char queryIndex = -1;
@@ -353,7 +351,7 @@ void reportAnalogCallback(byte analogPin, int value)
       analogInputsToReport = analogInputsToReport | (1 << analogPin);
       // prevent during system reset or all analog pin values will be reported
       // which may report noise for unconnected analog pins
-      if (!isResetting) {
+      if (!Firmata.isResetting()) {
         // Send pin value immediately. This is helpful when connected via
         // ethernet, wi-fi or bluetooth so pin states can be known upon
         // reconnecting.
@@ -616,7 +614,6 @@ void disableI2CPins() {
 
 void systemResetCallback()
 {
-  isResetting = true;
   // initialize a defalt state
   // TODO: option to load config from EEPROM instead of default
   if (isI2CEnabled) {
@@ -657,7 +654,6 @@ void systemResetCallback()
     outputPort(i, readPort(i, portConfigInputs[i]), true);
   }
   */
-  isResetting = false;
 }
 
 void setup()

--- a/utility/AnalogInputFirmata.cpp
+++ b/utility/AnalogInputFirmata.cpp
@@ -46,7 +46,7 @@ void AnalogInputFirmata::reportAnalog(byte analogPin, int value)
       analogInputsToReport = analogInputsToReport | (1 << analogPin);
       // prevent during system reset or all analog pin values will be reported
       // which may report noise for unconnected analog pins
-      if (Firmata.isResetting()) {
+      if (!Firmata.isResetting()) {
         // Send pin value immediately. This is helpful when connected via
         // ethernet, wi-fi or bluetooth so pin states can be known upon
         // reconnecting.

--- a/utility/AnalogInputFirmata.cpp
+++ b/utility/AnalogInputFirmata.cpp
@@ -44,7 +44,14 @@ void AnalogInputFirmata::reportAnalog(byte analogPin, int value)
       analogInputsToReport = analogInputsToReport &~ (1 << analogPin);
     } else {
       analogInputsToReport = analogInputsToReport | (1 << analogPin);
-      Firmata.sendAnalog(analogPin, analogRead(analogPin));
+      // prevent during system reset or all analog pin values will be reported
+      // which may report noise for unconnected analog pins
+      if (Firmata.isResetting()) {
+        // Send pin value immediately. This is helpful when connected via
+        // ethernet, wi-fi or bluetooth so pin states can be known upon
+        // reconnecting.
+        Firmata.sendAnalog(analogPin, analogRead(analogPin));
+      }
     }
   }
   // TODO: save status to EEPROM here, if changed


### PR DESCRIPTION
Fixes an issue where all analog pins values are reported when systemReset is called, even if no analog pins are used. This was crashing at least one client library (PyMata) and sending noise for any unused analog input.