### PR TITLE
Add tone support to StandardFirmata.

### DIFF
--- a/Firmata.h
+++ b/Firmata.h
@@ -41,6 +41,7 @@
 
 // extended command set using sysex (0-127/0x00-0x7F)
 /* 0x00-0x0F reserved for user-defined commands */
+#define TONE_DATA               0x5F // send a tone or noTone command
 #define ENCODER_DATA            0x61 // reply with encoders current positions
 #define SERVO_CONFIG            0x70 // set max angle, minPulse, maxPulse, freq
 #define STRING_DATA             0x71 // a string message with 14-bits per char
@@ -79,8 +80,9 @@
 #define ONEWIRE                 0x07 // pin configured for 1-wire
 #define STEPPER                 0x08 // pin configured for stepper motor
 #define ENCODER                 0x09 // pin configured for rotary encoders
+#define TONE                    0x0A // pin configured for tone function
 #define IGNORE                  0x7F // pin configured to be ignored by digitalWrite and capabilityResponse
-#define TOTAL_PIN_MODES         11
+#define TOTAL_PIN_MODES         12
 
 extern "C" {
   // callback function types


### PR DESCRIPTION
As described here:
https://github.com/firmata/protocol/blob/master/tone-proposal.md

The tone branch provides support for tone() and noTone() in ConfigurableFirmata, but it would be great to have them in StandardFirmata too.