### PR TITLE
implement protocol to set digital pin value

### DIFF
--- a/Firmata.cpp
+++ b/Firmata.cpp
@@ -238,6 +238,10 @@ void FirmataClass::processInput(void)
           if (currentPinModeCallback)
             (*currentPinModeCallback)(storedInputData[1], storedInputData[0]);
           break;
+        case SET_DIGITAL_PIN_VALUE:
+          if (currentPinValueCallback)
+            (*currentPinValueCallback)(storedInputData[1], storedInputData[0]);
+          break;
         case REPORT_ANALOG:
           if (currentReportAnalogCallback)
             (*currentReportAnalogCallback)(multiByteChannel, storedInputData[0]);
@@ -262,6 +266,7 @@ void FirmataClass::processInput(void)
       case ANALOG_MESSAGE:
       case DIGITAL_MESSAGE:
       case SET_PIN_MODE:
+      case SET_DIGITAL_PIN_VALUE:
         waitForData = 2; // two data bytes needed
         executeMultiByteCommand = command;
         break;
@@ -367,6 +372,7 @@ void FirmataClass::attach(byte command, callbackFunction newFunction)
     case REPORT_ANALOG: currentReportAnalogCallback = newFunction; break;
     case REPORT_DIGITAL: currentReportDigitalCallback = newFunction; break;
     case SET_PIN_MODE: currentPinModeCallback = newFunction; break;
+    case SET_DIGITAL_PIN_VALUE: currentPinValueCallback = newFunction; break;
   }
 }
 

--- a/Firmata.h
+++ b/Firmata.h
@@ -33,6 +33,8 @@
 //
 #define SET_PIN_MODE            0xF4 // set a pin to INPUT/OUTPUT/PWM/etc
 //
+#define SET_DIGITAL_PIN_VALUE   0xF5 // set value of an individual digital pin
+//
 #define REPORT_VERSION          0xF9 // report protocol version
 #define SYSTEM_RESET            0xFF // reset from MIDI
 //
@@ -150,6 +152,7 @@ class FirmataClass
     callbackFunction currentReportAnalogCallback;
     callbackFunction currentReportDigitalCallback;
     callbackFunction currentPinModeCallback;
+    callbackFunction currentPinValueCallback;
     systemResetCallbackFunction currentSystemResetCallback;
     stringCallbackFunction currentStringCallback;
     sysexCallbackFunction currentSysexCallback;

--- a/Firmata.h
+++ b/Firmata.h
@@ -32,7 +32,6 @@
 #define REPORT_DIGITAL          0xD0 // enable digital input by port pair
 //
 #define SET_PIN_MODE            0xF4 // set a pin to INPUT/OUTPUT/PWM/etc
-//
 #define SET_DIGITAL_PIN_VALUE   0xF5 // set value of an individual digital pin
 //
 #define REPORT_VERSION          0xF9 // report protocol version

--- a/examples/StandardFirmata/StandardFirmata.ino
+++ b/examples/StandardFirmata/StandardFirmata.ino
@@ -304,6 +304,20 @@ void setPinModeCallback(byte pin, int mode)
   // TODO: save status to EEPROM here, if changed
 }
 
+/*
+ * Sets the value of an individual pin.
+ * Useful if you want to set a pin value but are not tracking the digital port state.
+ */
+void setPinValueCallback(byte pin, int value)
+{
+  if (pin < TOTAL_PINS && IS_PIN_DIGITAL(pin)) {
+    if (pinConfig[pin] == OUTPUT || pinConfig[pin] == INPUT) {
+      pinState[pin] = value;
+      digitalWrite(PIN_TO_DIGITAL(pin), value);
+    }
+  }
+}
+
 void analogWriteCallback(byte pin, int value)
 {
   if (pin < TOTAL_PINS) {
@@ -674,6 +688,7 @@ void setup()
   Firmata.attach(REPORT_ANALOG, reportAnalogCallback);
   Firmata.attach(REPORT_DIGITAL, reportDigitalCallback);
   Firmata.attach(SET_PIN_MODE, setPinModeCallback);
+  Firmata.attach(SET_DIGITAL_PIN_VALUE, setPinValueCallback);
   Firmata.attach(START_SYSEX, sysexCallback);
   Firmata.attach(SYSTEM_RESET, systemResetCallback);
 

--- a/examples/StandardFirmataChipKIT/StandardFirmataChipKIT.ino
+++ b/examples/StandardFirmataChipKIT/StandardFirmataChipKIT.ino
@@ -315,6 +315,20 @@ void setPinModeCallback(byte pin, int mode)
   // TODO: save status to EEPROM here, if changed
 }
 
+/*
+ * Sets the value of an individual pin.
+ * Useful if you want to set a pin value but are not tracking the digital port state.
+ */
+void setPinValueCallback(byte pin, int value)
+{
+  if (pin < TOTAL_PINS && IS_PIN_DIGITAL(pin)) {
+    if (pinConfig[pin] == OUTPUT || pinConfig[pin] == INPUT) {
+      pinState[pin] = value;
+      digitalWrite(PIN_TO_DIGITAL(pin), value);
+    }
+  }
+}
+
 void analogWriteCallback(byte pin, int value)
 {
   if (pin < TOTAL_PINS) {
@@ -683,6 +697,7 @@ void setup()
   Firmata.attach(REPORT_ANALOG, reportAnalogCallback);
   Firmata.attach(REPORT_DIGITAL, reportDigitalCallback);
   Firmata.attach(SET_PIN_MODE, setPinModeCallback);
+  Firmata.attach(SET_DIGITAL_PIN_VALUE, setPinValueCallback);
   Firmata.attach(START_SYSEX, sysexCallback);
   Firmata.attach(SYSTEM_RESET, systemResetCallback);
 

--- a/examples/StandardFirmataEthernet/StandardFirmataEthernet.ino
+++ b/examples/StandardFirmataEthernet/StandardFirmataEthernet.ino
@@ -420,6 +420,20 @@ void setPinModeCallback(byte pin, int mode)
   // TODO: save status to EEPROM here, if changed
 }
 
+/*
+ * Sets the value of an individual pin.
+ * Useful if you want to set a pin value but are not tracking the digital port state.
+ */
+void setPinValueCallback(byte pin, int value)
+{
+  if (pin < TOTAL_PINS && IS_PIN_DIGITAL(pin)) {
+    if (pinConfig[pin] == OUTPUT || pinConfig[pin] == INPUT) {
+      pinState[pin] = value;
+      digitalWrite(PIN_TO_DIGITAL(pin), value);
+    }
+  }
+}
+
 void analogWriteCallback(byte pin, int value)
 {
   if (pin < TOTAL_PINS) {
@@ -804,6 +818,7 @@ void setup()
   Firmata.attach(REPORT_ANALOG, reportAnalogCallback);
   Firmata.attach(REPORT_DIGITAL, reportDigitalCallback);
   Firmata.attach(SET_PIN_MODE, setPinModeCallback);
+  Firmata.attach(SET_DIGITAL_PIN_VALUE, setPinValueCallback);
   Firmata.attach(START_SYSEX, sysexCallback);
   Firmata.attach(SYSTEM_RESET, systemResetCallback);
 

--- a/examples/StandardFirmataEthernetPlus/StandardFirmataEthernetPlus.ino
+++ b/examples/StandardFirmataEthernetPlus/StandardFirmataEthernetPlus.ino
@@ -510,6 +510,20 @@ void setPinModeCallback(byte pin, int mode)
   // TODO: save status to EEPROM here, if changed
 }
 
+/*
+ * Sets the value of an individual pin.
+ * Useful if you want to set a pin value but are not tracking the digital port state.
+ */
+void setPinValueCallback(byte pin, int value)
+{
+  if (pin < TOTAL_PINS && IS_PIN_DIGITAL(pin)) {
+    if (pinConfig[pin] == OUTPUT || pinConfig[pin] == INPUT) {
+      pinState[pin] = value;
+      digitalWrite(PIN_TO_DIGITAL(pin), value);
+    }
+  }
+}
+
 void analogWriteCallback(byte pin, int value)
 {
   if (pin < TOTAL_PINS) {
@@ -1056,6 +1070,7 @@ void setup()
   Firmata.attach(REPORT_ANALOG, reportAnalogCallback);
   Firmata.attach(REPORT_DIGITAL, reportDigitalCallback);
   Firmata.attach(SET_PIN_MODE, setPinModeCallback);
+  Firmata.attach(SET_DIGITAL_PIN_VALUE, setPinValueCallback);
   Firmata.attach(START_SYSEX, sysexCallback);
   Firmata.attach(SYSTEM_RESET, systemResetCallback);
 

--- a/examples/StandardFirmataPlus/StandardFirmataPlus.ino
+++ b/examples/StandardFirmataPlus/StandardFirmataPlus.ino
@@ -442,6 +442,20 @@ void setPinModeCallback(byte pin, int mode)
   // TODO: save status to EEPROM here, if changed
 }
 
+/*
+ * Sets the value of an individual pin.
+ * Useful if you want to set a pin value but are not tracking the digital port state.
+ */
+void setPinValueCallback(byte pin, int value)
+{
+  if (pin < TOTAL_PINS && IS_PIN_DIGITAL(pin)) {
+    if (pinConfig[pin] == OUTPUT || pinConfig[pin] == INPUT) {
+      pinState[pin] = value;
+      digitalWrite(PIN_TO_DIGITAL(pin), value);
+    }
+  }
+}
+
 void analogWriteCallback(byte pin, int value)
 {
   if (pin < TOTAL_PINS) {
@@ -982,6 +996,7 @@ void setup()
   Firmata.attach(REPORT_ANALOG, reportAnalogCallback);
   Firmata.attach(REPORT_DIGITAL, reportDigitalCallback);
   Firmata.attach(SET_PIN_MODE, setPinModeCallback);
+  Firmata.attach(SET_DIGITAL_PIN_VALUE, setPinValueCallback);
   Firmata.attach(START_SYSEX, sysexCallback);
   Firmata.attach(SYSTEM_RESET, systemResetCallback);
 

--- a/examples/StandardFirmataYun/StandardFirmataYun.ino
+++ b/examples/StandardFirmataYun/StandardFirmataYun.ino
@@ -316,6 +316,20 @@ void setPinModeCallback(byte pin, int mode)
   // TODO: save status to EEPROM here, if changed
 }
 
+/*
+ * Sets the value of an individual pin.
+ * Useful if you want to set a pin value but are not tracking the digital port state.
+ */
+void setPinValueCallback(byte pin, int value)
+{
+  if (pin < TOTAL_PINS && IS_PIN_DIGITAL(pin)) {
+    if (pinConfig[pin] == OUTPUT || pinConfig[pin] == INPUT) {
+      pinState[pin] = value;
+      digitalWrite(PIN_TO_DIGITAL(pin), value);
+    }
+  }
+}
+
 void analogWriteCallback(byte pin, int value)
 {
   if (pin < TOTAL_PINS) {
@@ -698,6 +712,7 @@ void setup()
   Firmata.attach(REPORT_ANALOG, reportAnalogCallback);
   Firmata.attach(REPORT_DIGITAL, reportDigitalCallback);
   Firmata.attach(SET_PIN_MODE, setPinModeCallback);
+  Firmata.attach(SET_DIGITAL_PIN_VALUE, setPinValueCallback);
   Firmata.attach(START_SYSEX, sysexCallback);
   Firmata.attach(SYSTEM_RESET, systemResetCallback);
 


### PR DESCRIPTION
Implements the protocol for [setting a digital pin value](https://github.com/firmata/protocol/blob/master/protocol.md#message-types).

Was previously in the v2.5.beta1 branch but needed to merge other commits from that branch earlier.

This PR adds a new feature so it will require bumping the Firmata minor version when merged.