### PR TITLE
Moving Firmata constants into separate file to allow direct linking in C projects

### DIFF
--- a/Firmata.h
+++ b/Firmata.h
@@ -14,73 +14,7 @@
 #define Firmata_h
 
 #include "Boards.h"  /* Hardware Abstraction Layer + Wiring/Arduino */
-
-/* Version numbers for the protocol.  The protocol is still changing, so these
- * version numbers are important.  This number can be queried so that host
- * software can test whether it will be compatible with the currently
- * installed firmware. */
-#define FIRMATA_MAJOR_VERSION   2 // for non-compatible changes
-#define FIRMATA_MINOR_VERSION   4 // for backwards compatible changes
-#define FIRMATA_BUGFIX_VERSION  4 // for bugfix releases
-
-#define MAX_DATA_BYTES          64 // max number of data bytes in incoming messages
-
-// message command bytes (128-255/0x80-0xFF)
-#define DIGITAL_MESSAGE         0x90 // send data for a digital port (collection of 8 pins)
-#define ANALOG_MESSAGE          0xE0 // send data for an analog pin (or PWM)
-#define REPORT_ANALOG           0xC0 // enable analog input by pin #
-#define REPORT_DIGITAL          0xD0 // enable digital input by port pair
-//
-#define SET_PIN_MODE            0xF4 // set a pin to INPUT/OUTPUT/PWM/etc
-//
-#define REPORT_VERSION          0xF9 // report protocol version
-#define SYSTEM_RESET            0xFF // reset from MIDI
-//
-#define START_SYSEX             0xF0 // start a MIDI Sysex message
-#define END_SYSEX               0xF7 // end a MIDI Sysex message
-
-// extended command set using sysex (0-127/0x00-0x7F)
-/* 0x00-0x0F reserved for user-defined commands */
-#define ENCODER_DATA            0x61 // reply with encoders current positions
-#define SERVO_CONFIG            0x70 // set max angle, minPulse, maxPulse, freq
-#define STRING_DATA             0x71 // a string message with 14-bits per char
-#define STEPPER_DATA            0x72 // control a stepper motor
-#define ONEWIRE_DATA            0x73 // send an OneWire read/write/reset/select/skip/search request
-#define SHIFT_DATA              0x75 // a bitstream to/from a shift register
-#define I2C_REQUEST             0x76 // send an I2C read/write request
-#define I2C_REPLY               0x77 // a reply to an I2C read request
-#define I2C_CONFIG              0x78 // config I2C settings such as delay times and power pins
-#define EXTENDED_ANALOG         0x6F // analog write (PWM, Servo, etc) to any pin
-#define PIN_STATE_QUERY         0x6D // ask for a pin's current mode and value
-#define PIN_STATE_RESPONSE      0x6E // reply with pin's current mode and value
-#define CAPABILITY_QUERY        0x6B // ask for supported modes and resolution of all pins
-#define CAPABILITY_RESPONSE     0x6C // reply with supported modes and resolution
-#define ANALOG_MAPPING_QUERY    0x69 // ask for mapping of analog to pin numbers
-#define ANALOG_MAPPING_RESPONSE 0x6A // reply with mapping info
-#define REPORT_FIRMWARE         0x79 // report name and version of the firmware
-#define SAMPLING_INTERVAL       0x7A // set the poll rate of the main loop
-#define SCHEDULER_DATA          0x7B // send a createtask/deletetask/addtotask/schedule/querytasks/querytask request to the scheduler
-#define SYSEX_NON_REALTIME      0x7E // MIDI Reserved for non-realtime messages
-#define SYSEX_REALTIME          0x7F // MIDI Reserved for realtime messages
-// these are DEPRECATED to make the naming more consistent
-#define FIRMATA_STRING          0x71 // same as STRING_DATA
-#define SYSEX_I2C_REQUEST       0x76 // same as I2C_REQUEST
-#define SYSEX_I2C_REPLY         0x77 // same as I2C_REPLY
-#define SYSEX_SAMPLING_INTERVAL 0x7A // same as SAMPLING_INTERVAL
-
-// pin modes
-//#define INPUT                 0x00 // defined in Arduino.h
-//#define OUTPUT                0x01 // defined in Arduino.h
-#define ANALOG                  0x02 // analog pin in analogInput mode
-#define PWM                     0x03 // digital pin in PWM output mode
-#define SERVO                   0x04 // digital pin in Servo output mode
-#define SHIFT                   0x05 // shiftIn/shiftOut mode
-#define I2C                     0x06 // pin included in I2C setup
-#define ONEWIRE                 0x07 // pin configured for 1-wire
-#define STEPPER                 0x08 // pin configured for stepper motor
-#define ENCODER                 0x09 // pin configured for rotary encoders
-#define IGNORE                  0x7F // pin configured to be ignored by digitalWrite and capabilityResponse
-#define TOTAL_PIN_MODES         11
+#include "Firmata_Constants.h" /* Constants used by the protocol */
 
 extern "C" {
   // callback function types

--- a/constants/Firmata_Constants.h
+++ b/constants/Firmata_Constants.h
@@ -1,0 +1,85 @@
+/*
+ Firmata_Constants.h - Firmata library v2.4.4 - 2015-8-9
+ Copyright (c) 2006-2008 Hans-Christoph Steiner.  All rights reserved.
+ 
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+ 
+ See file LICENSE.txt for further informations on licensing terms.
+ */
+
+#ifndef Firmata_Constants_h
+#define Firmata_Constants_h
+
+#pragma mark - Version numbers
+/* Version numbers for the protocol.  The protocol is still changing, so these
+ * version numbers are important.  This number can be queried so that host
+ * software can test whether it will be compatible with the currently
+ * installed firmware. */
+#define FIRMATA_MAJOR_VERSION   2 // for non-compatible changes
+#define FIRMATA_MINOR_VERSION   4 // for backwards compatible changes
+#define FIRMATA_BUGFIX_VERSION  4 // for bugfix releases
+
+#define MAX_DATA_BYTES          64 // max number of data bytes in incoming messages
+
+#pragma mark - message command bytes (128-255/0x80-0xFF)
+#define DIGITAL_MESSAGE         0x90 // send data for a digital port (collection of 8 pins)
+#define ANALOG_MESSAGE          0xE0 // send data for an analog pin (or PWM)
+#define REPORT_ANALOG           0xC0 // enable analog input by pin #
+#define REPORT_DIGITAL          0xD0 // enable digital input by port pair
+//
+#define SET_PIN_MODE            0xF4 // set a pin to INPUT/OUTPUT/PWM/etc
+//
+#define REPORT_VERSION          0xF9 // report protocol version
+#define SYSTEM_RESET            0xFF // reset from MIDI
+//
+#define START_SYSEX             0xF0 // start a MIDI Sysex message
+#define END_SYSEX               0xF7 // end a MIDI Sysex message
+
+#pragma mark - extended command set using sysex (0-127/0x00-0x7F)
+/* 0x00-0x0F reserved for user-defined commands */
+#define ENCODER_DATA            0x61 // reply with encoders current positions
+#define SERVO_CONFIG            0x70 // set max angle, minPulse, maxPulse, freq
+#define STRING_DATA             0x71 // a string message with 14-bits per char
+#define STEPPER_DATA            0x72 // control a stepper motor
+#define ONEWIRE_DATA            0x73 // send an OneWire read/write/reset/select/skip/search request
+#define SHIFT_DATA              0x75 // a bitstream to/from a shift register
+#define I2C_REQUEST             0x76 // send an I2C read/write request
+#define I2C_REPLY               0x77 // a reply to an I2C read request
+#define I2C_CONFIG              0x78 // config I2C settings such as delay times and power pins
+#define EXTENDED_ANALOG         0x6F // analog write (PWM, Servo, etc) to any pin
+#define PIN_STATE_QUERY         0x6D // ask for a pin's current mode and value
+#define PIN_STATE_RESPONSE      0x6E // reply with pin's current mode and value
+#define CAPABILITY_QUERY        0x6B // ask for supported modes and resolution of all pins
+#define CAPABILITY_RESPONSE     0x6C // reply with supported modes and resolution
+#define ANALOG_MAPPING_QUERY    0x69 // ask for mapping of analog to pin numbers
+#define ANALOG_MAPPING_RESPONSE 0x6A // reply with mapping info
+#define REPORT_FIRMWARE         0x79 // report name and version of the firmware
+#define SAMPLING_INTERVAL       0x7A // set the poll rate of the main loop
+#define SCHEDULER_DATA          0x7B // send a createtask/deletetask/addtotask/schedule/querytasks/querytask request to the scheduler
+#define SYSEX_NON_REALTIME      0x7E // MIDI Reserved for non-realtime messages
+#define SYSEX_REALTIME          0x7F // MIDI Reserved for realtime messages
+// these are DEPRECATED to make the naming more consistent
+#define FIRMATA_STRING          0x71 // same as STRING_DATA
+#define SYSEX_I2C_REQUEST       0x76 // same as I2C_REQUEST
+#define SYSEX_I2C_REPLY         0x77 // same as I2C_REPLY
+#define SYSEX_SAMPLING_INTERVAL 0x7A // same as SAMPLING_INTERVAL
+
+// pin modes
+//#define INPUT                 0x00 // defined in Arduino.h
+//#define OUTPUT                0x01 // defined in Arduino.h
+#define ANALOG                  0x02 // analog pin in analogInput mode
+#define PWM                     0x03 // digital pin in PWM output mode
+#define SERVO                   0x04 // digital pin in Servo output mode
+#define SHIFT                   0x05 // shiftIn/shiftOut mode
+#define I2C                     0x06 // pin included in I2C setup
+#define ONEWIRE                 0x07 // pin configured for 1-wire
+#define STEPPER                 0x08 // pin configured for stepper motor
+#define ENCODER                 0x09 // pin configured for rotary encoders
+#define IGNORE                  0x7F // pin configured to be ignored by digitalWrite and capabilityResponse
+#define TOTAL_PIN_MODES         11
+
+
+#endif /* Firmata_Constants_h */


### PR DESCRIPTION
I'm working with ADArduino and iFirmata client libraries and found that each used its own (version of) the Firmata constants. Including Firmata.h doesn't work because of its dependencies on other arduino classes which have no place in a client library. The easiest solution is to move the constants into their own header file. To facilitate modular checking out and inclusion by way of Subversion externals, the Firmata_Constants header should be in its own folder.
To clarify, the structure that I'm proposing is:

arduino
- constants
  -  Firmata_Constants.h
- Firmata.h        (#import "Firmata_Constants.h")
- Firmata.cpp   (no changes)
-   ...
