### PR TITLE
lower min sampling interval to 1ms

### DIFF
--- a/examples/StandardFirmata/StandardFirmata.ino
+++ b/examples/StandardFirmata/StandardFirmata.ino
@@ -37,7 +37,7 @@
 #define I2C_REGISTER_NOT_SPECIFIED  -1
 
 // the minimum interval for sampling analog input
-#define MINIMUM_SAMPLING_INTERVAL   10
+#define MINIMUM_SAMPLING_INTERVAL   1
 
 
 /*==============================================================================

--- a/examples/StandardFirmataChipKIT/StandardFirmataChipKIT.ino
+++ b/examples/StandardFirmataChipKIT/StandardFirmataChipKIT.ino
@@ -38,7 +38,7 @@
 #define I2C_REGISTER_NOT_SPECIFIED  -1
 
 // the minimum interval for sampling analog input
-#define MINIMUM_SAMPLING_INTERVAL   10
+#define MINIMUM_SAMPLING_INTERVAL   1
 
 
 /*==============================================================================

--- a/examples/StandardFirmataEthernet/StandardFirmataEthernet.ino
+++ b/examples/StandardFirmataEthernet/StandardFirmataEthernet.ino
@@ -65,7 +65,7 @@
 #define I2C_REGISTER_NOT_SPECIFIED  -1
 
 // the minimum interval for sampling analog input
-#define MINIMUM_SAMPLING_INTERVAL   10
+#define MINIMUM_SAMPLING_INTERVAL   1
 
 
 /*==============================================================================

--- a/examples/StandardFirmataEthernetPlus/StandardFirmataEthernetPlus.ino
+++ b/examples/StandardFirmataEthernetPlus/StandardFirmataEthernetPlus.ino
@@ -80,7 +80,7 @@
 #define I2C_REGISTER_NOT_SPECIFIED  -1
 
 // the minimum interval for sampling analog input
-#define MINIMUM_SAMPLING_INTERVAL   10
+#define MINIMUM_SAMPLING_INTERVAL   1
 
 
 /*==============================================================================

--- a/examples/StandardFirmataPlus/StandardFirmataPlus.ino
+++ b/examples/StandardFirmataPlus/StandardFirmataPlus.ino
@@ -63,7 +63,7 @@
 #define I2C_REGISTER_NOT_SPECIFIED  -1
 
 // the minimum interval for sampling analog input
-#define MINIMUM_SAMPLING_INTERVAL   10
+#define MINIMUM_SAMPLING_INTERVAL   1
 
 
 /*==============================================================================

--- a/examples/StandardFirmataYun/StandardFirmataYun.ino
+++ b/examples/StandardFirmataYun/StandardFirmataYun.ino
@@ -49,7 +49,7 @@
 #define I2C_REGISTER_NOT_SPECIFIED  -1
 
 // the minimum interval for sampling analog input
-#define MINIMUM_SAMPLING_INTERVAL 10
+#define MINIMUM_SAMPLING_INTERVAL   1
 
 
 /*==============================================================================


### PR DESCRIPTION
However users must be careful to not set the min value to lower than what their board can handler per the number of operations it runs per loop. General rule, if lower the value and the board starts acting weird, raise the value until you no longer observe issues.