### PR TITLE
Add support for Arduino Zero

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -242,6 +242,29 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #define PIN_TO_SERVO(p)         ((p) - 2)
 
 
+// Arduino Zero
+// Note this will work with an Arduino Zero Pro, but not with an Arduino M0 Pro
+// Arduino M0 Pro does not properly map pins to the board labeled pin numbers
+#elif defined(_VARIANT_ARDUINO_ZERO_)
+#define TOTAL_ANALOG_PINS       6
+#define TOTAL_PINS              25 // 14 digital + 6 analog + 2 i2c + 3 spi
+#define TOTAL_PORTS             3 // set when TOTAL_PINS > num digitial I/O pins
+#define VERSION_BLINK_PIN       LED_BUILTIN
+#define DAC_RESOLUTION          10
+#define IS_PIN_DIGITAL(p)       ((p) >= 0 && (p) <= 19)
+#define IS_PIN_ANALOG(p)        ((p) >= 14 && (p) < 14 + TOTAL_ANALOG_PINS)
+#define IS_PIN_PWM(p)           (digitalPinHasPWM(p) || (p) == 14) // use DAC0 as a PWM pin
+#define IS_PIN_SERVO(p)         (IS_PIN_DIGITAL(p) && (p) < MAX_SERVOS) // deprecated since v2.4
+#define IS_PIN_I2C(p)           ((p) == 20 || (p) == 21) // SDA = 20, SCL = 21
+#define IS_PIN_SPI(p)           ((p) == SS || (p) == MOSI || (p) == MISO || (p) == SCK) // SS = A2
+#define IS_PIN_SERIAL(p)        ((p) == 0 || (p) == 1)
+#define IS_PIN_DAC(p)           ((p) == 14)
+#define PIN_TO_DIGITAL(p)       (p)
+#define PIN_TO_ANALOG(p)        ((p) - 14)
+#define PIN_TO_PWM(p)           PIN_TO_DIGITAL(p)
+#define PIN_TO_SERVO(p)         (p) // deprecated since v2.4
+
+
 // Teensy 1.0
 #elif defined(__AVR_AT90USB162__)
 #define TOTAL_ANALOG_PINS       0
@@ -573,6 +596,11 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 
 #ifndef IS_PIN_SERIAL
 #define IS_PIN_SERIAL(p)        0
+#endif
+
+#ifndef IS_PIN_DAC
+#define IS_PIN_DAC(p)           0
+#define DAC_RESOLUTION          8
 #endif
 
 /*==============================================================================

--- a/Boards.h
+++ b/Boards.h
@@ -248,17 +248,17 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #elif defined(_VARIANT_ARDUINO_ZERO_)
 #define TOTAL_ANALOG_PINS       6
 #define TOTAL_PINS              25 // 14 digital + 6 analog + 2 i2c + 3 spi
-#define TOTAL_PORTS             3 // set when TOTAL_PINS > num digitial I/O pins
+#define TOTAL_PORTS             3  // set when TOTAL_PINS > num digitial I/O pins
 #define VERSION_BLINK_PIN       LED_BUILTIN
-#define DAC_RESOLUTION          10
+#define PIN_SERIAL1_RX          0
+#define PIN_SERIAL1_TX          1
 #define IS_PIN_DIGITAL(p)       ((p) >= 0 && (p) <= 19)
 #define IS_PIN_ANALOG(p)        ((p) >= 14 && (p) < 14 + TOTAL_ANALOG_PINS)
-#define IS_PIN_PWM(p)           (digitalPinHasPWM(p) || (p) == 14) // use DAC0 as a PWM pin
+#define IS_PIN_PWM(p)           digitalPinHasPWM(p)
 #define IS_PIN_SERVO(p)         (IS_PIN_DIGITAL(p) && (p) < MAX_SERVOS) // deprecated since v2.4
 #define IS_PIN_I2C(p)           ((p) == 20 || (p) == 21) // SDA = 20, SCL = 21
 #define IS_PIN_SPI(p)           ((p) == SS || (p) == MOSI || (p) == MISO || (p) == SCK) // SS = A2
 #define IS_PIN_SERIAL(p)        ((p) == 0 || (p) == 1)
-#define IS_PIN_DAC(p)           ((p) == 14)
 #define PIN_TO_DIGITAL(p)       (p)
 #define PIN_TO_ANALOG(p)        ((p) - 14)
 #define PIN_TO_PWM(p)           PIN_TO_DIGITAL(p)
@@ -598,10 +598,6 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #define IS_PIN_SERIAL(p)        0
 #endif
 
-#ifndef IS_PIN_DAC
-#define IS_PIN_DAC(p)           0
-#define DAC_RESOLUTION          8
-#endif
 
 /*==============================================================================
  * readPort() - Read an 8 bit port

--- a/examples/StandardFirmata/StandardFirmata.ino
+++ b/examples/StandardFirmata/StandardFirmata.ino
@@ -255,7 +255,10 @@ void setPinModeCallback(byte pin, int mode)
       if (IS_PIN_ANALOG(pin)) {
         if (IS_PIN_DIGITAL(pin)) {
           pinMode(PIN_TO_DIGITAL(pin), INPUT);    // disable output driver
+#if ARDUINO <= 100
+          // deprecated since Arduino 1.0.1 - TODO: drop support in Firmata 2.5
           digitalWrite(PIN_TO_DIGITAL(pin), LOW); // disable internal pull-ups
+#endif
         }
         pinConfig[pin] = ANALOG;
       }
@@ -263,7 +266,10 @@ void setPinModeCallback(byte pin, int mode)
     case INPUT:
       if (IS_PIN_DIGITAL(pin)) {
         pinMode(PIN_TO_DIGITAL(pin), INPUT);    // disable output driver
+#if ARDUINO <= 100
+        // deprecated since Arduino 1.0.1 - TODO: drop support in Firmata 2.5
         digitalWrite(PIN_TO_DIGITAL(pin), LOW); // disable internal pull-ups
+#endif
         pinConfig[pin] = INPUT;
       }
       break;

--- a/examples/StandardFirmata/StandardFirmata.ino
+++ b/examples/StandardFirmata/StandardFirmata.ino
@@ -311,13 +311,15 @@ void setPinModeCallback(byte pin, int mode)
 }
 
 /*
- * Sets the value of an individual pin.
- * Useful if you want to set a pin value but are not tracking the digital port state.
+ * Sets the value of an individual pin. Useful if you want to set a pin value but
+ * are not tracking the digital port state.
+ * Can only be used on pins configured as OUTPUT.
+ * Cannot be used to enable pull-ups on Digital INPUT pins.
  */
 void setPinValueCallback(byte pin, int value)
 {
   if (pin < TOTAL_PINS && IS_PIN_DIGITAL(pin)) {
-    if (pinConfig[pin] == OUTPUT || pinConfig[pin] == INPUT) {
+    if (pinConfig[pin] == OUTPUT) {
       pinState[pin] = value;
       digitalWrite(PIN_TO_DIGITAL(pin), value);
     }
@@ -353,13 +355,19 @@ void digitalWriteCallback(byte port, int value)
     for (pin = port * 8; pin < lastPin; pin++) {
       // do not disturb non-digital pins (eg, Rx & Tx)
       if (IS_PIN_DIGITAL(pin)) {
-        // only write to OUTPUT and INPUT (enables pullup)
         // do not touch pins in PWM, ANALOG, SERVO or other modes
         if (pinConfig[pin] == OUTPUT || pinConfig[pin] == INPUT) {
           pinValue = ((byte)value & mask) ? 1 : 0;
-          // temporary fix until INPUT_PULLUP is added
-          if (pinConfig[pin] == OUTPUT || (pinConfig[pin] == INPUT && pinValue == 1)) {
+          if (pinConfig[pin] == OUTPUT) {
             pinWriteMask |= mask;
+          } else if (pinConfig[pin] == INPUT && pinValue == 1 && pinState[pin] != 1) {
+            // only handle INPUT here for backwards compatibility
+#if ARDUINO > 100
+            pinMode(pin, INPUT_PULLUP);
+#else
+            // only write to the INPUT pin to enable pullups if Arduino v1.0.0 or earlier
+            pinWriteMask |= mask;
+#endif
           }
           pinState[pin] = pinValue;
         }

--- a/examples/StandardFirmata/StandardFirmata.ino
+++ b/examples/StandardFirmata/StandardFirmata.ino
@@ -344,7 +344,7 @@ void analogWriteCallback(byte pin, int value)
 
 void digitalWriteCallback(byte port, int value)
 {
-  byte pin, lastPin, mask = 1, pinWriteMask = 0;
+  byte pin, lastPin, pinValue, mask = 1, pinWriteMask = 0;
 
   if (port < TOTAL_PORTS) {
     // create a mask of the pins on this port that are writable.
@@ -356,8 +356,12 @@ void digitalWriteCallback(byte port, int value)
         // only write to OUTPUT and INPUT (enables pullup)
         // do not touch pins in PWM, ANALOG, SERVO or other modes
         if (pinConfig[pin] == OUTPUT || pinConfig[pin] == INPUT) {
-          pinWriteMask |= mask;
-          pinState[pin] = ((byte)value & mask) ? 1 : 0;
+          pinValue = ((byte)value & mask) ? 1 : 0;
+          // temporary fix until INPUT_PULLUP is added
+          if (pinConfig[pin] == OUTPUT || (pinConfig[pin] == INPUT && pinValue == 1)) {
+            pinWriteMask |= mask;
+          }
+          pinState[pin] = pinValue;
         }
       }
       mask = mask << 1;

--- a/examples/StandardFirmata/StandardFirmata.ino
+++ b/examples/StandardFirmata/StandardFirmata.ino
@@ -20,7 +20,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated by Jeff Hoefs: August 9th, 2015
+  Last updated by Jeff Hoefs: October 24th, 2015
 */
 
 #include <Servo.h>
@@ -654,7 +654,7 @@ void systemResetCallback()
     if (IS_PIN_ANALOG(i)) {
       // turns off pullup, configures everything
       setPinModeCallback(i, ANALOG);
-    } else {
+    } else if (IS_PIN_DIGITAL(i)) {
       // sets the output to 0, configures portConfigInputs
       setPinModeCallback(i, OUTPUT);
     }

--- a/examples/StandardFirmataChipKIT/StandardFirmataChipKIT.ino
+++ b/examples/StandardFirmataChipKIT/StandardFirmataChipKIT.ino
@@ -266,7 +266,10 @@ void setPinModeCallback(byte pin, int mode)
       if (IS_PIN_ANALOG(pin)) {
         if (IS_PIN_DIGITAL(pin)) {
           pinMode(PIN_TO_DIGITAL(pin), INPUT);    // disable output driver
+#if ARDUINO <= 100
+          // deprecated since Arduino 1.0.1 - TODO: drop support in Firmata 2.5
           digitalWrite(PIN_TO_DIGITAL(pin), LOW); // disable internal pull-ups
+#endif
         }
         pinConfig[pin] = ANALOG;
       }
@@ -274,7 +277,10 @@ void setPinModeCallback(byte pin, int mode)
     case INPUT:
       if (IS_PIN_DIGITAL(pin)) {
         pinMode(PIN_TO_DIGITAL(pin), INPUT);    // disable output driver
+#if ARDUINO <= 100
+        // deprecated since Arduino 1.0.1 - TODO: drop support in Firmata 2.5
         digitalWrite(PIN_TO_DIGITAL(pin), LOW); // disable internal pull-ups
+#endif
         pinConfig[pin] = INPUT;
       }
       break;

--- a/examples/StandardFirmataChipKIT/StandardFirmataChipKIT.ino
+++ b/examples/StandardFirmataChipKIT/StandardFirmataChipKIT.ino
@@ -355,7 +355,7 @@ void analogWriteCallback(byte pin, int value)
 
 void digitalWriteCallback(byte port, int value)
 {
-  byte pin, lastPin, mask = 1, pinWriteMask = 0;
+  byte pin, lastPin, pinValue, mask = 1, pinWriteMask = 0;
 
   if (port < TOTAL_PORTS) {
     // create a mask of the pins on this port that are writable.
@@ -367,8 +367,12 @@ void digitalWriteCallback(byte port, int value)
         // only write to OUTPUT and INPUT (enables pullup)
         // do not touch pins in PWM, ANALOG, SERVO or other modes
         if (pinConfig[pin] == OUTPUT || pinConfig[pin] == INPUT) {
-          pinWriteMask |= mask;
-          pinState[pin] = ((byte)value & mask) ? 1 : 0;
+          pinValue = ((byte)value & mask) ? 1 : 0;
+          // temporary fix until INPUT_PULLUP is added
+          if (pinConfig[pin] == OUTPUT || (pinConfig[pin] == INPUT && pinValue == 1)) {
+            pinWriteMask |= mask;
+          }
+          pinState[pin] = pinValue;
         }
       }
       mask = mask << 1;

--- a/examples/StandardFirmataChipKIT/StandardFirmataChipKIT.ino
+++ b/examples/StandardFirmataChipKIT/StandardFirmataChipKIT.ino
@@ -21,7 +21,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated by Brian Schmalz: August 9th, 2015
+  Last updated by Jeff Hoefs: October 24th, 2015
 */
 
 #include <SoftPWMServo.h>  // Gives us PWM and Servo on every pin
@@ -663,7 +663,7 @@ void systemResetCallback()
     if (IS_PIN_ANALOG(i)) {
       // turns off pullup, configures everything
       setPinModeCallback(i, ANALOG);
-    } else {
+    } else if (IS_PIN_DIGITAL(i)) {
       // sets the output to 0, configures portConfigInputs
       setPinModeCallback(i, OUTPUT);
     }

--- a/examples/StandardFirmataChipKIT/StandardFirmataChipKIT.ino
+++ b/examples/StandardFirmataChipKIT/StandardFirmataChipKIT.ino
@@ -322,13 +322,15 @@ void setPinModeCallback(byte pin, int mode)
 }
 
 /*
- * Sets the value of an individual pin.
- * Useful if you want to set a pin value but are not tracking the digital port state.
+ * Sets the value of an individual pin. Useful if you want to set a pin value but
+ * are not tracking the digital port state.
+ * Can only be used on pins configured as OUTPUT.
+ * Cannot be used to enable pull-ups on Digital INPUT pins.
  */
 void setPinValueCallback(byte pin, int value)
 {
   if (pin < TOTAL_PINS && IS_PIN_DIGITAL(pin)) {
-    if (pinConfig[pin] == OUTPUT || pinConfig[pin] == INPUT) {
+    if (pinConfig[pin] == OUTPUT) {
       pinState[pin] = value;
       digitalWrite(PIN_TO_DIGITAL(pin), value);
     }
@@ -364,13 +366,19 @@ void digitalWriteCallback(byte port, int value)
     for (pin = port * 8; pin < lastPin; pin++) {
       // do not disturb non-digital pins (eg, Rx & Tx)
       if (IS_PIN_DIGITAL(pin)) {
-        // only write to OUTPUT and INPUT (enables pullup)
         // do not touch pins in PWM, ANALOG, SERVO or other modes
         if (pinConfig[pin] == OUTPUT || pinConfig[pin] == INPUT) {
           pinValue = ((byte)value & mask) ? 1 : 0;
-          // temporary fix until INPUT_PULLUP is added
-          if (pinConfig[pin] == OUTPUT || (pinConfig[pin] == INPUT && pinValue == 1)) {
+          if (pinConfig[pin] == OUTPUT) {
             pinWriteMask |= mask;
+          } else if (pinConfig[pin] == INPUT && pinValue == 1 && pinState[pin] != 1) {
+            // only handle INPUT here for backwards compatibility
+#if ARDUINO > 100
+            pinMode(pin, INPUT_PULLUP);
+#else
+            // only write to the INPUT pin to enable pullups if Arduino v1.0.0 or earlier
+            pinWriteMask |= mask;
+#endif
           }
           pinState[pin] = pinValue;
         }

--- a/examples/StandardFirmataEthernet/StandardFirmataEthernet.ino
+++ b/examples/StandardFirmataEthernet/StandardFirmataEthernet.ino
@@ -460,7 +460,7 @@ void analogWriteCallback(byte pin, int value)
 
 void digitalWriteCallback(byte port, int value)
 {
-  byte pin, lastPin, mask = 1, pinWriteMask = 0;
+  byte pin, lastPin, pinValue, mask = 1, pinWriteMask = 0;
 
   if (port < TOTAL_PORTS) {
     // create a mask of the pins on this port that are writable.
@@ -472,8 +472,12 @@ void digitalWriteCallback(byte port, int value)
         // only write to OUTPUT and INPUT (enables pullup)
         // do not touch pins in PWM, ANALOG, SERVO or other modes
         if (pinConfig[pin] == OUTPUT || pinConfig[pin] == INPUT) {
-          pinWriteMask |= mask;
-          pinState[pin] = ((byte)value & mask) ? 1 : 0;
+          pinValue = ((byte)value & mask) ? 1 : 0;
+          // temporary fix until INPUT_PULLUP is added
+          if (pinConfig[pin] == OUTPUT || (pinConfig[pin] == INPUT && pinValue == 1)) {
+            pinWriteMask |= mask;
+          }
+          pinState[pin] = pinValue;
         }
       }
       mask = mask << 1;

--- a/examples/StandardFirmataEthernet/StandardFirmataEthernet.ino
+++ b/examples/StandardFirmataEthernet/StandardFirmataEthernet.ino
@@ -20,7 +20,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated by Jeff Hoefs: August 9th, 2015
+  Last updated by Jeff Hoefs: October 24th, 2015
 */
 
 /*
@@ -770,7 +770,7 @@ void systemResetCallback()
     if (IS_PIN_ANALOG(i)) {
       // turns off pullup, configures everything
       setPinModeCallback(i, ANALOG);
-    } else {
+    } else if (IS_PIN_DIGITAL(i)) {
       // sets the output to 0, configures portConfigInputs
       setPinModeCallback(i, OUTPUT);
     }

--- a/examples/StandardFirmataEthernet/StandardFirmataEthernet.ino
+++ b/examples/StandardFirmataEthernet/StandardFirmataEthernet.ino
@@ -371,7 +371,10 @@ void setPinModeCallback(byte pin, int mode)
       if (IS_PIN_ANALOG(pin)) {
         if (IS_PIN_DIGITAL(pin)) {
           pinMode(PIN_TO_DIGITAL(pin), INPUT);    // disable output driver
+#if ARDUINO <= 100
+          // deprecated since Arduino 1.0.1 - TODO: drop support in Firmata 2.5
           digitalWrite(PIN_TO_DIGITAL(pin), LOW); // disable internal pull-ups
+#endif
         }
         pinConfig[pin] = ANALOG;
       }
@@ -379,7 +382,10 @@ void setPinModeCallback(byte pin, int mode)
     case INPUT:
       if (IS_PIN_DIGITAL(pin)) {
         pinMode(PIN_TO_DIGITAL(pin), INPUT);    // disable output driver
+#if ARDUINO <= 100
+        // deprecated since Arduino 1.0.1 - TODO: drop support in Firmata 2.5
         digitalWrite(PIN_TO_DIGITAL(pin), LOW); // disable internal pull-ups
+#endif
         pinConfig[pin] = INPUT;
       }
       break;

--- a/examples/StandardFirmataEthernetPlus/StandardFirmataEthernetPlus.ino
+++ b/examples/StandardFirmataEthernetPlus/StandardFirmataEthernetPlus.ino
@@ -550,7 +550,7 @@ void analogWriteCallback(byte pin, int value)
 
 void digitalWriteCallback(byte port, int value)
 {
-  byte pin, lastPin, mask = 1, pinWriteMask = 0;
+  byte pin, lastPin, pinValue, mask = 1, pinWriteMask = 0;
 
   if (port < TOTAL_PORTS) {
     // create a mask of the pins on this port that are writable.
@@ -562,8 +562,12 @@ void digitalWriteCallback(byte port, int value)
         // only write to OUTPUT and INPUT (enables pullup)
         // do not touch pins in PWM, ANALOG, SERVO or other modes
         if (pinConfig[pin] == OUTPUT || pinConfig[pin] == INPUT) {
-          pinWriteMask |= mask;
-          pinState[pin] = ((byte)value & mask) ? 1 : 0;
+          pinValue = ((byte)value & mask) ? 1 : 0;
+          // temporary fix until INPUT_PULLUP is added
+          if (pinConfig[pin] == OUTPUT || (pinConfig[pin] == INPUT && pinValue == 1)) {
+            pinWriteMask |= mask;
+          }
+          pinState[pin] = pinValue;
         }
       }
       mask = mask << 1;

--- a/examples/StandardFirmataEthernetPlus/StandardFirmataEthernetPlus.ino
+++ b/examples/StandardFirmataEthernetPlus/StandardFirmataEthernetPlus.ino
@@ -461,7 +461,10 @@ void setPinModeCallback(byte pin, int mode)
       if (IS_PIN_ANALOG(pin)) {
         if (IS_PIN_DIGITAL(pin)) {
           pinMode(PIN_TO_DIGITAL(pin), INPUT);    // disable output driver
+#if ARDUINO <= 100
+          // deprecated since Arduino 1.0.1 - TODO: drop support in Firmata 2.5
           digitalWrite(PIN_TO_DIGITAL(pin), LOW); // disable internal pull-ups
+#endif
         }
         pinConfig[pin] = ANALOG;
       }
@@ -469,7 +472,10 @@ void setPinModeCallback(byte pin, int mode)
     case INPUT:
       if (IS_PIN_DIGITAL(pin)) {
         pinMode(PIN_TO_DIGITAL(pin), INPUT);    // disable output driver
+#if ARDUINO <= 100
+        // deprecated since Arduino 1.0.1 - TODO: drop support in Firmata 2.5
         digitalWrite(PIN_TO_DIGITAL(pin), LOW); // disable internal pull-ups
+#endif
         pinConfig[pin] = INPUT;
       }
       break;

--- a/examples/StandardFirmataEthernetPlus/StandardFirmataEthernetPlus.ino
+++ b/examples/StandardFirmataEthernetPlus/StandardFirmataEthernetPlus.ino
@@ -20,7 +20,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated by Jeff Hoefs: October 4th, 2015
+  Last updated by Jeff Hoefs: October 24th, 2015
 */
 
 /*
@@ -1026,7 +1026,7 @@ void systemResetCallback()
     if (IS_PIN_ANALOG(i)) {
       // turns off pullup, configures everything
       setPinModeCallback(i, ANALOG);
-    } else {
+    } else if (IS_PIN_DIGITAL(i)) {
       // sets the output to 0, configures portConfigInputs
       setPinModeCallback(i, OUTPUT);
     }

--- a/examples/StandardFirmataEthernetPlus/StandardFirmataEthernetPlus.ino
+++ b/examples/StandardFirmataEthernetPlus/StandardFirmataEthernetPlus.ino
@@ -517,13 +517,15 @@ void setPinModeCallback(byte pin, int mode)
 }
 
 /*
- * Sets the value of an individual pin.
- * Useful if you want to set a pin value but are not tracking the digital port state.
+ * Sets the value of an individual pin. Useful if you want to set a pin value but
+ * are not tracking the digital port state.
+ * Can only be used on pins configured as OUTPUT.
+ * Cannot be used to enable pull-ups on Digital INPUT pins.
  */
 void setPinValueCallback(byte pin, int value)
 {
   if (pin < TOTAL_PINS && IS_PIN_DIGITAL(pin)) {
-    if (pinConfig[pin] == OUTPUT || pinConfig[pin] == INPUT) {
+    if (pinConfig[pin] == OUTPUT) {
       pinState[pin] = value;
       digitalWrite(PIN_TO_DIGITAL(pin), value);
     }
@@ -559,13 +561,19 @@ void digitalWriteCallback(byte port, int value)
     for (pin = port * 8; pin < lastPin; pin++) {
       // do not disturb non-digital pins (eg, Rx & Tx)
       if (IS_PIN_DIGITAL(pin)) {
-        // only write to OUTPUT and INPUT (enables pullup)
         // do not touch pins in PWM, ANALOG, SERVO or other modes
         if (pinConfig[pin] == OUTPUT || pinConfig[pin] == INPUT) {
           pinValue = ((byte)value & mask) ? 1 : 0;
-          // temporary fix until INPUT_PULLUP is added
-          if (pinConfig[pin] == OUTPUT || (pinConfig[pin] == INPUT && pinValue == 1)) {
+          if (pinConfig[pin] == OUTPUT) {
             pinWriteMask |= mask;
+          } else if (pinConfig[pin] == INPUT && pinValue == 1 && pinState[pin] != 1) {
+            // only handle INPUT here for backwards compatibility
+#if ARDUINO > 100
+            pinMode(pin, INPUT_PULLUP);
+#else
+            // only write to the INPUT pin to enable pullups if Arduino v1.0.0 or earlier
+            pinWriteMask |= mask;
+#endif
           }
           pinState[pin] = pinValue;
         }

--- a/examples/StandardFirmataPlus/StandardFirmataPlus.ino
+++ b/examples/StandardFirmataPlus/StandardFirmataPlus.ino
@@ -962,7 +962,7 @@ void systemResetCallback()
     if (IS_PIN_ANALOG(i)) {
       // turns off pullup, configures everything
       setPinModeCallback(i, ANALOG);
-    } else {
+    } else if (IS_PIN_DIGITAL(i)) {
       // sets the output to 0, configures portConfigInputs
       setPinModeCallback(i, OUTPUT);
     }

--- a/examples/StandardFirmataPlus/StandardFirmataPlus.ino
+++ b/examples/StandardFirmataPlus/StandardFirmataPlus.ino
@@ -482,7 +482,7 @@ void analogWriteCallback(byte pin, int value)
 
 void digitalWriteCallback(byte port, int value)
 {
-  byte pin, lastPin, mask = 1, pinWriteMask = 0;
+  byte pin, lastPin, pinValue, mask = 1, pinWriteMask = 0;
 
   if (port < TOTAL_PORTS) {
     // create a mask of the pins on this port that are writable.
@@ -494,8 +494,12 @@ void digitalWriteCallback(byte port, int value)
         // only write to OUTPUT and INPUT (enables pullup)
         // do not touch pins in PWM, ANALOG, SERVO or other modes
         if (pinConfig[pin] == OUTPUT || pinConfig[pin] == INPUT) {
-          pinWriteMask |= mask;
-          pinState[pin] = ((byte)value & mask) ? 1 : 0;
+          pinValue = ((byte)value & mask) ? 1 : 0;
+          // temporary fix until INPUT_PULLUP is added
+          if (pinConfig[pin] == OUTPUT || (pinConfig[pin] == INPUT && pinValue == 1)) {
+            pinWriteMask |= mask;
+          }
+          pinState[pin] = pinValue;
         }
       }
       mask = mask << 1;

--- a/examples/StandardFirmataPlus/StandardFirmataPlus.ino
+++ b/examples/StandardFirmataPlus/StandardFirmataPlus.ino
@@ -389,7 +389,10 @@ void setPinModeCallback(byte pin, int mode)
       if (IS_PIN_ANALOG(pin)) {
         if (IS_PIN_DIGITAL(pin)) {
           pinMode(PIN_TO_DIGITAL(pin), INPUT);    // disable output driver
+#if ARDUINO <= 100
+          // deprecated since Arduino 1.0.1 - TODO: drop support in Firmata 2.5
           digitalWrite(PIN_TO_DIGITAL(pin), LOW); // disable internal pull-ups
+#endif
         }
         pinConfig[pin] = ANALOG;
       }
@@ -397,7 +400,10 @@ void setPinModeCallback(byte pin, int mode)
     case INPUT:
       if (IS_PIN_DIGITAL(pin)) {
         pinMode(PIN_TO_DIGITAL(pin), INPUT);    // disable output driver
+#if ARDUINO <= 100
+        // deprecated since Arduino 1.0.1 - TODO: drop support in Firmata 2.5
         digitalWrite(PIN_TO_DIGITAL(pin), LOW); // disable internal pull-ups
+#endif
         pinConfig[pin] = INPUT;
       }
       break;

--- a/examples/StandardFirmataPlus/StandardFirmataPlus.ino
+++ b/examples/StandardFirmataPlus/StandardFirmataPlus.ino
@@ -449,13 +449,15 @@ void setPinModeCallback(byte pin, int mode)
 }
 
 /*
- * Sets the value of an individual pin.
- * Useful if you want to set a pin value but are not tracking the digital port state.
+ * Sets the value of an individual pin. Useful if you want to set a pin value but
+ * are not tracking the digital port state.
+ * Can only be used on pins configured as OUTPUT.
+ * Cannot be used to enable pull-ups on Digital INPUT pins.
  */
 void setPinValueCallback(byte pin, int value)
 {
   if (pin < TOTAL_PINS && IS_PIN_DIGITAL(pin)) {
-    if (pinConfig[pin] == OUTPUT || pinConfig[pin] == INPUT) {
+    if (pinConfig[pin] == OUTPUT) {
       pinState[pin] = value;
       digitalWrite(PIN_TO_DIGITAL(pin), value);
     }
@@ -491,13 +493,19 @@ void digitalWriteCallback(byte port, int value)
     for (pin = port * 8; pin < lastPin; pin++) {
       // do not disturb non-digital pins (eg, Rx & Tx)
       if (IS_PIN_DIGITAL(pin)) {
-        // only write to OUTPUT and INPUT (enables pullup)
         // do not touch pins in PWM, ANALOG, SERVO or other modes
         if (pinConfig[pin] == OUTPUT || pinConfig[pin] == INPUT) {
           pinValue = ((byte)value & mask) ? 1 : 0;
-          // temporary fix until INPUT_PULLUP is added
-          if (pinConfig[pin] == OUTPUT || (pinConfig[pin] == INPUT && pinValue == 1)) {
+          if (pinConfig[pin] == OUTPUT) {
             pinWriteMask |= mask;
+          } else if (pinConfig[pin] == INPUT && pinValue == 1 && pinState[pin] != 1) {
+            // only handle INPUT here for backwards compatibility
+#if ARDUINO > 100
+            pinMode(pin, INPUT_PULLUP);
+#else
+            // only write to the INPUT pin to enable pullups if Arduino v1.0.0 or earlier
+            pinWriteMask |= mask;
+#endif
           }
           pinState[pin] = pinValue;
         }

--- a/examples/StandardFirmataYun/StandardFirmataYun.ino
+++ b/examples/StandardFirmataYun/StandardFirmataYun.ino
@@ -356,7 +356,7 @@ void analogWriteCallback(byte pin, int value)
 
 void digitalWriteCallback(byte port, int value)
 {
-  byte pin, lastPin, mask = 1, pinWriteMask = 0;
+  byte pin, lastPin, pinValue, mask = 1, pinWriteMask = 0;
 
   if (port < TOTAL_PORTS) {
     // create a mask of the pins on this port that are writable.
@@ -368,8 +368,12 @@ void digitalWriteCallback(byte port, int value)
         // only write to OUTPUT and INPUT (enables pullup)
         // do not touch pins in PWM, ANALOG, SERVO or other modes
         if (pinConfig[pin] == OUTPUT || pinConfig[pin] == INPUT) {
-          pinWriteMask |= mask;
-          pinState[pin] = ((byte)value & mask) ? 1 : 0;
+          pinValue = ((byte)value & mask) ? 1 : 0;
+          // temporary fix until INPUT_PULLUP is added
+          if (pinConfig[pin] == OUTPUT || (pinConfig[pin] == INPUT && pinValue == 1)) {
+            pinWriteMask |= mask;
+          }
+          pinState[pin] = pinValue;
         }
       }
       mask = mask << 1;

--- a/examples/StandardFirmataYun/StandardFirmataYun.ino
+++ b/examples/StandardFirmataYun/StandardFirmataYun.ino
@@ -267,7 +267,10 @@ void setPinModeCallback(byte pin, int mode)
       if (IS_PIN_ANALOG(pin)) {
         if (IS_PIN_DIGITAL(pin)) {
           pinMode(PIN_TO_DIGITAL(pin), INPUT);    // disable output driver
+#if ARDUINO <= 100
+          // deprecated since Arduino 1.0.1 - TODO: drop support in Firmata 2.5
           digitalWrite(PIN_TO_DIGITAL(pin), LOW); // disable internal pull-ups
+#endif
         }
         pinConfig[pin] = ANALOG;
       }
@@ -275,7 +278,10 @@ void setPinModeCallback(byte pin, int mode)
     case INPUT:
       if (IS_PIN_DIGITAL(pin)) {
         pinMode(PIN_TO_DIGITAL(pin), INPUT);    // disable output driver
+#if ARDUINO <= 100
+        // deprecated since Arduino 1.0.1 - TODO: drop support in Firmata 2.5
         digitalWrite(PIN_TO_DIGITAL(pin), LOW); // disable internal pull-ups
+#endif
         pinConfig[pin] = INPUT;
       }
       break;

--- a/examples/StandardFirmataYun/StandardFirmataYun.ino
+++ b/examples/StandardFirmataYun/StandardFirmataYun.ino
@@ -21,7 +21,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated by Jeff Hoefs: August 9th, 2015
+  Last updated by Jeff Hoefs: October 24th, 2015
  */
 
 /*
@@ -666,7 +666,7 @@ void systemResetCallback()
     if (IS_PIN_ANALOG(i)) {
       // turns off pullup, configures everything
       setPinModeCallback(i, ANALOG);
-    } else {
+    } else if (IS_PIN_DIGITAL(i)) {
       // sets the output to 0, configures portConfigInputs
       setPinModeCallback(i, OUTPUT);
     }

--- a/examples/StandardFirmataYun/StandardFirmataYun.ino
+++ b/examples/StandardFirmataYun/StandardFirmataYun.ino
@@ -323,13 +323,15 @@ void setPinModeCallback(byte pin, int mode)
 }
 
 /*
- * Sets the value of an individual pin.
- * Useful if you want to set a pin value but are not tracking the digital port state.
+ * Sets the value of an individual pin. Useful if you want to set a pin value but
+ * are not tracking the digital port state.
+ * Can only be used on pins configured as OUTPUT.
+ * Cannot be used to enable pull-ups on Digital INPUT pins.
  */
 void setPinValueCallback(byte pin, int value)
 {
   if (pin < TOTAL_PINS && IS_PIN_DIGITAL(pin)) {
-    if (pinConfig[pin] == OUTPUT || pinConfig[pin] == INPUT) {
+    if (pinConfig[pin] == OUTPUT) {
       pinState[pin] = value;
       digitalWrite(PIN_TO_DIGITAL(pin), value);
     }
@@ -365,13 +367,19 @@ void digitalWriteCallback(byte port, int value)
     for (pin = port * 8; pin < lastPin; pin++) {
       // do not disturb non-digital pins (eg, Rx & Tx)
       if (IS_PIN_DIGITAL(pin)) {
-        // only write to OUTPUT and INPUT (enables pullup)
         // do not touch pins in PWM, ANALOG, SERVO or other modes
         if (pinConfig[pin] == OUTPUT || pinConfig[pin] == INPUT) {
           pinValue = ((byte)value & mask) ? 1 : 0;
-          // temporary fix until INPUT_PULLUP is added
-          if (pinConfig[pin] == OUTPUT || (pinConfig[pin] == INPUT && pinValue == 1)) {
+          if (pinConfig[pin] == OUTPUT) {
             pinWriteMask |= mask;
+          } else if (pinConfig[pin] == INPUT && pinValue == 1 && pinState[pin] != 1) {
+            // only handle INPUT here for backwards compatibility
+#if ARDUINO > 100
+            pinMode(pin, INPUT_PULLUP);
+#else
+            // only write to the INPUT pin to enable pullups if Arduino v1.0.0 or earlier
+            pinWriteMask |= mask;
+#endif
           }
           pinState[pin] = pinValue;
         }


### PR DESCRIPTION
You will need an official Arduino Pro Zero board. Do not get an M0 Pro board, that will not work with Firmata.

In order to use, you'll have to make sure the Servo library is at least version 1.1.0.  Follow these instructions:
1. In the Arduino IDE (the arduino.cc one), go to Sketch > Include libraries > Manage libraries.
2. Search for "Servo" and scroll down the results list to "Servo by Michael Margolis..."
3. Tap on the list item (I wish this was more clear in the UI), then an option to Update will appear
4. Click on update.

TODO:
- [x] Ensure only digital I/O pins are reset in `systemResetCallback`
- [ ] Thorough testing