### PR TITLE
eliminate Firmata related compiler warnings

### DIFF
--- a/examples/StandardFirmata/StandardFirmata.ino
+++ b/examples/StandardFirmata/StandardFirmata.ino
@@ -20,7 +20,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated by Jeff Hoefs: December 9th, 2015
+  Last updated by Jeff Hoefs: December 20th, 2015
 */
 
 #include <Servo.h>
@@ -517,6 +517,7 @@ void sysexCallback(byte command, byte argc, byte *argv)
           if (queryIndex <= 0) {
             queryIndex = -1;
           } else {
+            queryIndexToSkip = 0;
             // if read continuous mode is enabled for multiple devices,
             // determine which device to stop reading and remove it's data from
             // the array, shifiting other array data to fill the space

--- a/examples/StandardFirmataChipKIT/StandardFirmataChipKIT.ino
+++ b/examples/StandardFirmataChipKIT/StandardFirmataChipKIT.ino
@@ -21,7 +21,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated by Jeff Hoefs: December 9th, 2015
+  Last updated by Jeff Hoefs: December 20th, 2015
 */
 
 #include <SoftPWMServo.h>  // Gives us PWM and Servo on every pin
@@ -528,6 +528,7 @@ void sysexCallback(byte command, byte argc, byte *argv)
           if (queryIndex <= 0) {
             queryIndex = -1;
           } else {
+            queryIndexToSkip = 0;
             // if read continuous mode is enabled for multiple devices,
             // determine which device to stop reading and remove it's data from
             // the array, shifiting other array data to fill the space

--- a/examples/StandardFirmataEthernet/StandardFirmataEthernet.ino
+++ b/examples/StandardFirmataEthernet/StandardFirmataEthernet.ino
@@ -20,7 +20,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated by Jeff Hoefs: December 9th, 2015
+  Last updated by Jeff Hoefs: December 20th, 2015
 */
 
 /*
@@ -635,6 +635,7 @@ void sysexCallback(byte command, byte argc, byte *argv)
           if (queryIndex <= 0) {
             queryIndex = -1;
           } else {
+            queryIndexToSkip = 0;
             // if read continuous mode is enabled for multiple devices,
             // determine which device to stop reading and remove it's data from
             // the array, shifiting other array data to fill the space

--- a/examples/StandardFirmataEthernetPlus/StandardFirmataEthernetPlus.ino
+++ b/examples/StandardFirmataEthernetPlus/StandardFirmataEthernetPlus.ino
@@ -20,7 +20,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated by Jeff Hoefs: December 19th, 2015
+  Last updated by Jeff Hoefs: December 20th, 2015
 */
 
 /*
@@ -723,6 +723,7 @@ void sysexCallback(byte command, byte argc, byte *argv)
           if (queryIndex <= 0) {
             queryIndex = -1;
           } else {
+            queryIndexToSkip = 0;
             // if read continuous mode is enabled for multiple devices,
             // determine which device to stop reading and remove it's data from
             // the array, shifiting other array data to fill the space
@@ -862,11 +863,6 @@ void sysexCallback(byte command, byte argc, byte *argv)
             byte swTxPin, swRxPin;
             serial_pins pins;
 
-            if (portId > 7 && argc > 4) {
-              swRxPin = argv[4];
-              swTxPin = argv[5];
-            }
-
             if (portId < 8) {
               serialPort = getPortFromId(portId);
               if (serialPort != NULL) {
@@ -882,6 +878,14 @@ void sysexCallback(byte command, byte argc, byte *argv)
               }
             } else {
 #if defined(SoftwareSerial_h)
+              if (argc > 4) {
+                swRxPin = argv[4];
+                swTxPin = argv[5];
+              } else {
+                // RX and TX pins must be specified when using SW serial
+                Firmata.sendString("Specify serial RX and TX pins");
+                return;
+              }
               switch (portId) {
                 case SW_SERIAL0:
                   if (swSerial0 == NULL) {
@@ -943,7 +947,7 @@ void sysexCallback(byte command, byte argc, byte *argv)
             serialIndex++;
             reportSerial[serialIndex] = portId;
           } else if (argv[1] == SERIAL_STOP_READING) {
-            byte serialIndexToSkip;
+            byte serialIndexToSkip = 0;
             if (serialIndex <= 0) {
               serialIndex = -1;
             } else {

--- a/examples/StandardFirmataPlus/StandardFirmataPlus.ino
+++ b/examples/StandardFirmataPlus/StandardFirmataPlus.ino
@@ -20,7 +20,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated by Jeff Hoefs: December 19th, 2015
+  Last updated by Jeff Hoefs: December 20th, 2015
 */
 
 /*
@@ -655,6 +655,7 @@ void sysexCallback(byte command, byte argc, byte *argv)
           if (queryIndex <= 0) {
             queryIndex = -1;
           } else {
+            queryIndexToSkip = 0;
             // if read continuous mode is enabled for multiple devices,
             // determine which device to stop reading and remove it's data from
             // the array, shifiting other array data to fill the space
@@ -798,11 +799,6 @@ void sysexCallback(byte command, byte argc, byte *argv)
             byte swTxPin, swRxPin;
             serial_pins pins;
 
-            if (portId > 7 && argc > 4) {
-              swRxPin = argv[4];
-              swTxPin = argv[5];
-            }
-
             if (portId < 8) {
               serialPort = getPortFromId(portId);
               if (serialPort != NULL) {
@@ -818,6 +814,14 @@ void sysexCallback(byte command, byte argc, byte *argv)
               }
             } else {
 #if defined(SoftwareSerial_h)
+              if (argc > 4) {
+                swRxPin = argv[4];
+                swTxPin = argv[5];
+              } else {
+                // RX and TX pins must be specified when using SW serial
+                Firmata.sendString("Specify serial RX and TX pins");
+                return;
+              }
               switch (portId) {
                 case SW_SERIAL0:
                   if (swSerial0 == NULL) {
@@ -879,7 +883,7 @@ void sysexCallback(byte command, byte argc, byte *argv)
             serialIndex++;
             reportSerial[serialIndex] = portId;
           } else if (argv[1] == SERIAL_STOP_READING) {
-            byte serialIndexToSkip;
+            byte serialIndexToSkip = 0;
             if (serialIndex <= 0) {
               serialIndex = -1;
             } else {

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ The second and more common model is to load a general purpose sketch called Stan
 ##Firmata Client Libraries
 Most of the time you will be interacting with Arduino with a client library on the host computers. Several Firmata client libraries have been implemented in a variety of popular programming languages:
 
-* procesing
+* processing
   * [https://github.com/firmata/processing]
   * [http://funnel.cc]
 * python

--- a/utility/EthernetClientStream.cpp
+++ b/utility/EthernetClientStream.cpp
@@ -26,12 +26,12 @@
 #define MILLIS_RECONNECT 5000
 
 EthernetClientStream::EthernetClientStream(Client &client, IPAddress localip, IPAddress ip, const char* host, uint16_t port)
-: ip(ip),
+: client(client),
+  localip(localip),
+  ip(ip),
   host(host),
   port(port),
-  connected(false),
-  client(client),
-  localip(localip)
+  connected(false)
 {
 }
 

--- a/utility/EthernetClientStream.h
+++ b/utility/EthernetClientStream.h
@@ -38,11 +38,11 @@ public:
   void maintain(IPAddress localip);
 
 private:
+  Client &client;
   IPAddress localip;
   IPAddress ip;
   const char* host;
   uint16_t port;
-  Client &client;
   bool connected;
   uint32_t time_connect;
   bool maintain();


### PR DESCRIPTION
refactor to eliminate Firmata-related compiler warnings showing up for Arduino 101 (which appears to have stricter flags set than other boards).