### PR TITLE
make VERSION_BLINK_PIN optional

### DIFF
--- a/Firmata.cpp
+++ b/Firmata.cpp
@@ -93,12 +93,14 @@ void FirmataClass::printVersion(void)
 
 void FirmataClass::blinkVersion(void)
 {
+#if defined(VERSION_BLINK_PIN)
   // flash the pin with the protocol version
   pinMode(VERSION_BLINK_PIN, OUTPUT);
-  strobeBlinkPin(FIRMATA_MAJOR_VERSION, 40, 210);
+  strobeBlinkPin(VERSION_BLINK_PIN, FIRMATA_MAJOR_VERSION, 40, 210);
   delay(250);
-  strobeBlinkPin(FIRMATA_MINOR_VERSION, 40, 210);
+  strobeBlinkPin(VERSION_BLINK_PIN, FIRMATA_MINOR_VERSION, 40, 210);
   delay(125);
+#endif
 }
 
 void FirmataClass::printFirmwareVersion(void)
@@ -160,7 +162,6 @@ int FirmataClass::available(void)
 {
   return FirmataStream->available();
 }
-
 
 void FirmataClass::processSysexMessage(void)
 {
@@ -330,7 +331,6 @@ void FirmataClass::sendDigitalPort(byte portNumber, int portData)
   FirmataStream->write(portData >> 7);  // Tx bits 7-13
 }
 
-
 void FirmataClass::sendSysex(byte command, byte bytec, byte *bytev)
 {
   byte i;
@@ -347,7 +347,6 @@ void FirmataClass::sendString(byte command, const char *string)
   sendSysex(command, strlen(string), (byte *)string);
 }
 
-
 // send a string as the protocol string type
 void FirmataClass::sendString(const char *string)
 {
@@ -359,7 +358,6 @@ void FirmataClass::write(byte c)
 {
   FirmataStream->write(c);
 }
-
 
 // Internal Actions/////////////////////////////////////////////////////////////
 
@@ -428,8 +426,6 @@ void FirmataClass::detach(byte command)
 //* Private Methods
 //******************************************************************************
 
-
-
 // resets the system state upon a SYSTEM_RESET message from the host software
 void FirmataClass::systemReset(void)
 {
@@ -450,22 +446,18 @@ void FirmataClass::systemReset(void)
     (*currentSystemResetCallback)();
 }
 
-
-
 // =============================================================================
 // used for flashing the pin for the version number
-void FirmataClass::strobeBlinkPin(int count, int onInterval, int offInterval)
+void FirmataClass::strobeBlinkPin(byte pin, int count, int onInterval, int offInterval)
 {
   byte i;
-  pinMode(VERSION_BLINK_PIN, OUTPUT);
   for (i = 0; i < count; i++) {
     delay(offInterval);
-    digitalWrite(VERSION_BLINK_PIN, HIGH);
+    digitalWrite(pin, HIGH);
     delay(onInterval);
-    digitalWrite(VERSION_BLINK_PIN, LOW);
+    digitalWrite(pin, LOW);
   }
 }
-
 
 // make one instance for the user to use
 FirmataClass Firmata;

--- a/Firmata.h
+++ b/Firmata.h
@@ -173,7 +173,7 @@ class FirmataClass
     /* private methods ------------------------------ */
     void processSysexMessage(void);
     void systemReset(void);
-    void strobeBlinkPin(int count, int onInterval, int offInterval);
+    void strobeBlinkPin(byte pin, int count, int onInterval, int offInterval);
 };
 
 extern FirmataClass Firmata;


### PR DESCRIPTION
This is an alternative approach to: https://github.com/firmata/arduino/pull/247/files. However neither approach allows the user to override `VERSION_BLINK_PIN` if it is specified already in Boards.h for the board they are compiling against. This is because `VERSION_BLINK_PIN` is defined per board (that have an onboard LED) in Boards.h and Firmata.cpp includes Boards.h, so there is no way to `undef` `VERSION_BLINK_PIN` from the user's sketch.