### PR TITLE
provide a way to bypass the version blink sequence

### DIFF
--- a/Firmata.cpp
+++ b/Firmata.cpp
@@ -81,7 +81,10 @@ void FirmataClass::begin(void)
 }
 
 /**
- * Initialize the default Serial transport and  override the default baud.
+ * Initialize the default Serial transport and override the default baud.
+ * Sends the protocol version to the host application followed by the firmware version and name.
+ * blinkVersion is also called. To skip the call to blinkVersion, call Firmata.disableBlinkVersion()
+ * before calling Firmata.begin(baud).
  * @param speed The baud to use. 57600 baud is the default value.
  */
 void FirmataClass::begin(long speed)
@@ -89,8 +92,8 @@ void FirmataClass::begin(long speed)
   Serial.begin(speed);
   FirmataStream = &Serial;
   blinkVersion();
-  printVersion();
-  printFirmwareVersion();
+  printVersion();         // send the protocol version
+  printFirmwareVersion(); // send the firmware name and version
 }
 
 /**
@@ -130,6 +133,7 @@ void FirmataClass::printVersion(void)
 void FirmataClass::blinkVersion(void)
 {
 #if defined(VERSION_BLINK_PIN)
+  if (blinkVersionDisabled) return;
   // flash the pin with the protocol version
   pinMode(VERSION_BLINK_PIN, OUTPUT);
   strobeBlinkPin(VERSION_BLINK_PIN, FIRMATA_FIRMWARE_MAJOR_VERSION, 40, 210);
@@ -137,6 +141,16 @@ void FirmataClass::blinkVersion(void)
   strobeBlinkPin(VERSION_BLINK_PIN, FIRMATA_FIRMWARE_MINOR_VERSION, 40, 210);
   delay(125);
 #endif
+}
+
+/**
+ * Provides a means to disable the version blink sequence on the onboard LED, trimming startup
+ * time by a couple of seconds.
+ * Call this before Firmata.begin(). It only applies when using the default Serial transport.
+ */
+void FirmataClass::disableBlinkVersion()
+{
+  blinkVersionDisabled = true;
 }
 
 /**

--- a/Firmata.h
+++ b/Firmata.h
@@ -139,6 +139,7 @@ class FirmataClass
     void printFirmwareVersion(void);
     //void setFirmwareVersion(byte major, byte minor);  // see macro below
     void setFirmwareNameAndVersion(const char *name, byte major, byte minor);
+    void disableBlinkVersion();
     /* serial receive handling */
     int available(void);
     void processInput(void);
@@ -198,6 +199,8 @@ class FirmataClass
     systemResetCallbackFunction currentSystemResetCallback;
     stringCallbackFunction currentStringCallback;
     sysexCallbackFunction currentSysexCallback;
+
+    boolean blinkVersionDisabled = false;
 
     /* private methods ------------------------------ */
     void processSysexMessage(void);

--- a/examples/StandardFirmataPlus/StandardFirmataPlus.ino
+++ b/examples/StandardFirmataPlus/StandardFirmataPlus.ino
@@ -777,6 +777,9 @@ void setup()
   Firmata.attach(START_SYSEX, sysexCallback);
   Firmata.attach(SYSTEM_RESET, systemResetCallback);
 
+  // Save a couple of seconds by disabling the startup blink sequence.
+  Firmata.disableBlinkVersion();
+
   // to use a port other than Serial, such as Serial1 on an Arduino Leonardo or Mega,
   // Call begin(baud) on the alternate serial port and pass it to Firmata to begin like this:
   // Serial1.begin(57600);

--- a/keywords.txt
+++ b/keywords.txt
@@ -43,6 +43,7 @@ startSysex			KEYWORD2
 endSysex			KEYWORD2
 writePort			KEYWORD2
 readPort			KEYWORD2
+disableBlinkVersion		KEYWORD2
 
 
 #######################################


### PR DESCRIPTION
This provides a way to bypass the version blink sequence on startup. As the minor version gets longer, so does this blocking blink sequence. This only applies when using the default Serial transport (since blinkVersion is not called when passing a `Stream` reference to `Firmata.begin(stream)`. In other works there is no need to disable for Ethernet, WiFi or other non-Serial variants.

By default the blink sequence will still run unless `Firmata.disableBlinkVersion()` is called before `Firmata.begin()` or `Firmata.begin(baud)`.

StandardFirmataPlus now disables the blink sequence. I've kept it in StandardFirmata however due to user expectations (and there are likely instructions for looking for the sequence when running StandardFirmata).