### PR TITLE
enable baud rate for serial feature to be updated

### DIFF
--- a/utility/SerialFirmata.cpp
+++ b/utility/SerialFirmata.cpp
@@ -14,7 +14,7 @@
 
   - handlePinMode calls Firmata::setPinMode
 
-  Last updated by Jeff Hoefs: January 10th, 2016
+  Last updated by Jeff Hoefs: January 16th, 2016
 */
 
 #include "SerialFirmata.h"
@@ -199,6 +199,23 @@ boolean SerialFirmata::handleSysex(byte command, byte argc, byte *argv)
         }
         break; // SERIAL_LISTEN
 #endif
+      case SERIAL_UPDATE_BAUD:
+        serialPort = getPortFromId(portId);
+        if (serialPort == NULL) {
+          break;
+        }
+        long newBaud = (long)argv[1] | ((long)argv[2] << 7) | ((long)argv[3] << 14);
+        if (portId < 8) {
+          ((HardwareSerial*)serialPort)->end();
+          delay(100); // delay required for HW serial only
+          ((HardwareSerial*)serialPort)->begin(newBaud);
+        } else {
+#if defined(SoftwareSerial_h)
+          ((SoftwareSerial*)serialPort)->end();
+          ((SoftwareSerial*)serialPort)->begin(newBaud);
+#endif
+        }
+        break; // SERIAL_UPDATE_BAUD
     } // end switch
     return true;
   }

--- a/utility/SerialFirmata.h
+++ b/utility/SerialFirmata.h
@@ -15,7 +15,7 @@
   - Defines FIRMATA_SERIAL_FEATURE (could add to Configurable version as well)
   - Imports Firmata.h rather than ConfigurableFirmata.h
 
-  Last updated by Jeff Hoefs: January 10th, 2016
+  Last updated by Jeff Hoefs: January 16th, 2016
 */
 
 #ifndef SerialFirmata_h
@@ -65,6 +65,7 @@
 #define SERIAL_CLOSE                0x50
 #define SERIAL_FLUSH                0x60
 #define SERIAL_LISTEN               0x70
+#define SERIAL_UPDATE_BAUD          0x80
 
 // Serial read modes
 #define SERIAL_READ_CONTINUOUSLY    0x00


### PR DESCRIPTION
This is useful when you need to change the baud rate of a serial peripheral.
