### PR TITLE
pin functions based on board depended defaults

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -685,7 +685,7 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #define IS_PIN_INTERRUPT(p)     (((p) >= 0 && (p) <= 5) || ((p) >= 12 && (p) <= 15))
 #define IS_PIN_SERIAL(p)        ((p) == 1 || (p) == 3)
 #define PIN_TO_DIGITAL(p)       (p)
-#define PIN_TO_ANALOG(p)        (p)
+#define PIN_TO_ANALOG(p)        ((p) - 17)
 #define PIN_TO_PWM(p)           PIN_TO_DIGITAL(p)
 #define PIN_TO_SERVO(p)         (p)
 

--- a/Boards.h
+++ b/Boards.h
@@ -665,22 +665,29 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #define PIN_TO_PWM(p)           PIN_TO_DIGITAL(p)
 #define PIN_TO_SERVO(p)         ((p) - 2)
 
-// ESP8266 generic
+// ESP8266
+// hardware: TX0=1, TX1=2, RX0=3, MISO=12, MOSI=13, SCLK=14, CS=15, A0=17  
+// board depended defaults: LED_BUILTIN, SDA, SCL
+// note: boot mode GPIOs 0, 2 and 15 can be used as outputs (GPIOs 6-11 are in use for flash IO)
 #elif defined(ESP8266)
-#define TOTAL_ANALOG_PINS       0
-#define TOTAL_PINS              17
-#define VERSION_BLINK_PIN       4
-// #define IS_PIN_DIGITAL(p)       ((p) == 0 || (p) == 1 || (p) == 2 || (p) == 3 || (p) == 4 || (p) == 5 || (p) == 12 || (p) == 13 || (p) == 14 || (p) == 15 || (p) == 16) //for wifi dont protect serial pins because these things only have 2 pins otherwise
-#define IS_PIN_DIGITAL(p)       ((p) == 0 || (p) == 2 || (p) == 4 || (p) == 5 || (p) == 12 || (p) == 13 || (p) == 14 || (p) == 15 || (p) == 16)
-#define IS_PIN_ANALOG(p)        (false)
-#define IS_PIN_PWM(p)           (false)
-#define IS_PIN_SERVO(p)         ((p) >= 0 && (p) < MAX_SERVOS)
-#define IS_PIN_I2C(p)           (false)
-#define IS_PIN_SPI(p)           (false)
+#define TOTAL_ANALOG_PINS       1
+#define TOTAL_PINS              18 // 11 digital + 1 analog + 6 inaccessible
+#define VERSION_BLINK_PIN       LED_BUILTIN
+#define PIN_SERIAL_RX           3
+#define PIN_SERIAL_TX           1
+#define PIN_SERIAL1_TX          2
+#define IS_PIN_DIGITAL(p)       (((p) >= 0 && (p) <= 5) || ((p) >= 12 && (p) <= 16))
+#define IS_PIN_ANALOG(p)        ((p) == A0)
+#define IS_PIN_PWM(p)           IS_PIN_DIGITAL(p)
+#define IS_PIN_SERVO(p)         (IS_PIN_DIGITAL(p) && (p) < MAX_SERVOS)
+#define IS_PIN_I2C(p)           ((p) == SDA || (p) == SCL)
+#define IS_PIN_SPI(p)           ((p) >= 12 && (p) <= 15)
+#define IS_PIN_INTERRUPT(p)     (((p) >= 0 && (p) <= 5) || ((p) >= 12 && (p) <= 15))
+#define IS_PIN_SERIAL(p)        ((p) == 1 || (p) == 3)
 #define PIN_TO_DIGITAL(p)       (p)
-#define PIN_TO_ANALOG(p)        ((p) - 17)
+#define PIN_TO_ANALOG(p)        (p)
 #define PIN_TO_PWM(p)           PIN_TO_DIGITAL(p)
-#define PIN_TO_SERVO(p)         p
+#define PIN_TO_SERVO(p)         (p)
 
  
 // anything else

--- a/Boards.h
+++ b/Boards.h
@@ -666,24 +666,23 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #define PIN_TO_SERVO(p)         ((p) - 2)
 
 // ESP8266
-// hardware: TX0=1, TX1=2, RX0=3, MISO=12, MOSI=13, SCLK=14, CS=15, A0=17  
-// board depended defaults: LED_BUILTIN, SDA, SCL
-// note: boot mode GPIOs 0, 2 and 15 can be used as outputs (GPIOs 6-11 are in use for flash IO)
+// note: boot mode GPIOs 0, 2 and 15 can be used as outputs, GPIOs 6-11 are in use for flash IO
 #elif defined(ESP8266)
-#define TOTAL_ANALOG_PINS       1
-#define TOTAL_PINS              18 // 11 digital + 1 analog + 6 inaccessible
+#define TOTAL_ANALOG_PINS       NUM_ANALOG_INPUTS
+#define TOTAL_PINS              (NUM_DIGITAL_PINS > A0 + NUM_ANALOG_INPUTS ? NUM_DIGITAL_PINS : A0 + NUM_ANALOG_INPUTS)
+#define VERSION_BLINK_PIN       LED_BUILTIN
 #define PIN_SERIAL_RX           3
 #define PIN_SERIAL_TX           1
-#define IS_PIN_DIGITAL(p)       (((p) >= 0 && (p) <= 5) || ((p) >= 12 && (p) <= 16))
-#define IS_PIN_ANALOG(p)        ((p) == A0)
+#define IS_PIN_DIGITAL(p)       (((p) >= 0 && (p) <= 5) || ((p) >= 12 && (p) < (NUM_DIGITAL_PINS > A0 + NUM_ANALOG_INPUTS ? NUM_DIGITAL_PINS : A0)))
+#define IS_PIN_ANALOG(p)        ((p) >= A0 && (p) < A0 + NUM_ANALOG_INPUTS)
 #define IS_PIN_PWM(p)           IS_PIN_DIGITAL(p)
 #define IS_PIN_SERVO(p)         (IS_PIN_DIGITAL(p) && (p) < MAX_SERVOS)
 #define IS_PIN_I2C(p)           ((p) == SDA || (p) == SCL)
-#define IS_PIN_SPI(p)           ((p) >= 12 && (p) <= 15)
-#define IS_PIN_INTERRUPT(p)     (((p) >= 0 && (p) <= 5) || ((p) >= 12 && (p) <= 15))
-#define IS_PIN_SERIAL(p)        ((p) == 1 || (p) == 3)
+#define IS_PIN_SPI(p)           ((p) == SS || (p) == MOSI || (p) == MISO || (p) == SCK)
+#define IS_PIN_INTERRUPT(p)     digitalPinToInterrupt(p)
+#define IS_PIN_SERIAL(p)        ((p) == PIN_SERIAL_RX || (p) == PIN_SERIAL_TX)
 #define PIN_TO_DIGITAL(p)       (p)
-#define PIN_TO_ANALOG(p)        ((p) - 17)
+#define PIN_TO_ANALOG(p)        ((p) - A0)
 #define PIN_TO_PWM(p)           PIN_TO_DIGITAL(p)
 #define PIN_TO_SERVO(p)         (p)
 

--- a/Boards.h
+++ b/Boards.h
@@ -672,10 +672,8 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #elif defined(ESP8266)
 #define TOTAL_ANALOG_PINS       1
 #define TOTAL_PINS              18 // 11 digital + 1 analog + 6 inaccessible
-#define VERSION_BLINK_PIN       LED_BUILTIN
 #define PIN_SERIAL_RX           3
 #define PIN_SERIAL_TX           1
-#define PIN_SERIAL1_TX          2
 #define IS_PIN_DIGITAL(p)       (((p) >= 0 && (p) <= 5) || ((p) >= 12 && (p) <= 16))
 #define IS_PIN_ANALOG(p)        ((p) == A0)
 #define IS_PIN_PWM(p)           IS_PIN_DIGITAL(p)

--- a/Boards.h
+++ b/Boards.h
@@ -669,13 +669,12 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 // note: boot mode GPIOs 0, 2 and 15 can be used as outputs, GPIOs 6-11 are in use for flash IO
 #elif defined(ESP8266)
 #define TOTAL_ANALOG_PINS       NUM_ANALOG_INPUTS
-#define TOTAL_PINS              (NUM_DIGITAL_PINS > A0 + NUM_ANALOG_INPUTS ? NUM_DIGITAL_PINS : A0 + NUM_ANALOG_INPUTS)
-#define VERSION_BLINK_PIN       LED_BUILTIN
+#define TOTAL_PINS              A0 + NUM_ANALOG_INPUTS
 #define PIN_SERIAL_RX           3
 #define PIN_SERIAL_TX           1
-#define IS_PIN_DIGITAL(p)       (((p) >= 0 && (p) <= 5) || ((p) >= 12 && (p) < (NUM_DIGITAL_PINS > A0 + NUM_ANALOG_INPUTS ? NUM_DIGITAL_PINS : A0)))
+#define IS_PIN_DIGITAL(p)       (((p) >= 0 && (p) <= 5) || ((p) >= 12 && (p) < A0))
 #define IS_PIN_ANALOG(p)        ((p) >= A0 && (p) < A0 + NUM_ANALOG_INPUTS)
-#define IS_PIN_PWM(p)           IS_PIN_DIGITAL(p)
+#define IS_PIN_PWM(p)           digitalPinHasPWM(p)
 #define IS_PIN_SERVO(p)         (IS_PIN_DIGITAL(p) && (p) < MAX_SERVOS)
 #define IS_PIN_I2C(p)           ((p) == SDA || (p) == SCL)
 #define IS_PIN_SPI(p)           ((p) == SS || (p) == MOSI || (p) == MISO || (p) == SCK)

--- a/Boards.h
+++ b/Boards.h
@@ -678,7 +678,7 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #define IS_PIN_SERVO(p)         (IS_PIN_DIGITAL(p) && (p) < MAX_SERVOS)
 #define IS_PIN_I2C(p)           ((p) == SDA || (p) == SCL)
 #define IS_PIN_SPI(p)           ((p) == SS || (p) == MOSI || (p) == MISO || (p) == SCK)
-#define IS_PIN_INTERRUPT(p)     digitalPinToInterrupt(p)
+#define IS_PIN_INTERRUPT(p)     (digitalPinToInterrupt(p) > NOT_AN_INTERRUPT)
 #define IS_PIN_SERIAL(p)        ((p) == PIN_SERIAL_RX || (p) == PIN_SERIAL_TX)
 #define PIN_TO_DIGITAL(p)       (p)
 #define PIN_TO_ANALOG(p)        ((p) - A0)

--- a/Boards.h
+++ b/Boards.h
@@ -684,6 +684,7 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #define PIN_TO_ANALOG(p)        ((p) - A0)
 #define PIN_TO_PWM(p)           PIN_TO_DIGITAL(p)
 #define PIN_TO_SERVO(p)         (p)
+#define DEFAULT_PWM_RESOLUTION  10
 
  
 // anything else
@@ -700,6 +701,9 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #define IS_PIN_SERIAL(p)        0
 #endif
 
+#ifndef DEFAULT_PWM_RESOLUTION
+#define DEFAULT_PWM_RESOLUTION  8
+#endif
 
 /*==============================================================================
  * readPort() - Read an 8 bit port

--- a/examples/StandardFirmata/StandardFirmata.ino
+++ b/examples/StandardFirmata/StandardFirmata.ino
@@ -615,7 +615,7 @@ void sysexCallback(byte command, byte argc, byte *argv)
         }
         if (IS_PIN_PWM(pin)) {
           Firmata.write(PIN_MODE_PWM);
-          Firmata.write(8); // 8 = 8-bit resolution
+          Firmata.write(DEFAULT_PWM_RESOLUTION);
         }
         if (IS_PIN_DIGITAL(pin)) {
           Firmata.write(PIN_MODE_SERVO);

--- a/examples/StandardFirmataChipKIT/StandardFirmataChipKIT.ino
+++ b/examples/StandardFirmataChipKIT/StandardFirmataChipKIT.ino
@@ -616,7 +616,7 @@ void sysexCallback(byte command, byte argc, byte *argv)
         }
         if (IS_PIN_PWM(pin)) {
           Firmata.write(PIN_MODE_PWM);
-          Firmata.write(8); // 8 = 8-bit resolution
+          Firmata.write(DEFAULT_PWM_RESOLUTION);
         }
         if (IS_PIN_DIGITAL(pin)) {
           Firmata.write(PIN_MODE_SERVO);

--- a/examples/StandardFirmataEthernet/StandardFirmataEthernet.ino
+++ b/examples/StandardFirmataEthernet/StandardFirmataEthernet.ino
@@ -672,7 +672,7 @@ void sysexCallback(byte command, byte argc, byte *argv)
         }
         if (IS_PIN_PWM(pin)) {
           Firmata.write(PIN_MODE_PWM);
-          Firmata.write(8); // 8 = 8-bit resolution
+          Firmata.write(DEFAULT_PWM_RESOLUTION);
         }
         if (IS_PIN_DIGITAL(pin)) {
           Firmata.write(PIN_MODE_SERVO);

--- a/examples/StandardFirmataEthernetPlus/StandardFirmataEthernetPlus.ino
+++ b/examples/StandardFirmataEthernetPlus/StandardFirmataEthernetPlus.ino
@@ -680,7 +680,7 @@ void sysexCallback(byte command, byte argc, byte *argv)
         }
         if (IS_PIN_PWM(pin)) {
           Firmata.write(PIN_MODE_PWM);
-          Firmata.write(8); // 8 = 8-bit resolution
+          Firmata.write(DEFAULT_PWM_RESOLUTION);
         }
         if (IS_PIN_DIGITAL(pin)) {
           Firmata.write(PIN_MODE_SERVO);

--- a/examples/StandardFirmataPlus/StandardFirmataPlus.ino
+++ b/examples/StandardFirmataPlus/StandardFirmataPlus.ino
@@ -635,7 +635,7 @@ void sysexCallback(byte command, byte argc, byte *argv)
         }
         if (IS_PIN_PWM(pin)) {
           Firmata.write(PIN_MODE_PWM);
-          Firmata.write(8); // 8 = 8-bit resolution
+          Firmata.write(DEFAULT_PWM_RESOLUTION);
         }
         if (IS_PIN_DIGITAL(pin)) {
           Firmata.write(PIN_MODE_SERVO);

--- a/examples/StandardFirmataWiFi/StandardFirmataWiFi.ino
+++ b/examples/StandardFirmataWiFi/StandardFirmataWiFi.ino
@@ -692,7 +692,7 @@ void sysexCallback(byte command, byte argc, byte *argv)
         }
         if (IS_PIN_PWM(pin)) {
           Firmata.write(PIN_MODE_PWM);
-          Firmata.write(8); // 8 = 8-bit resolution
+          Firmata.write(DEFAULT_PWM_RESOLUTION);
         }
         if (IS_PIN_DIGITAL(pin)) {
           Firmata.write(PIN_MODE_SERVO);


### PR DESCRIPTION
to support different ESP8266 boad layouts, use board depended constants
from "...\esp8266\hardware\esp8266\2.1.0\variants\...\pins_arduino.h"

DOUT, DIN, I2C and SERIAL0 have been tested and are working with a HUZZA board