### PR TITLE
Intial BLE support for Arduino 101 and some BRL boards

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -449,6 +449,22 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #define PIN_TO_SERVO(p)         ((p) - 2)
 
 
+// RedBearLab BLE Nano with factory switch settings (S1 - S10)
+#elif defined(BLE_NANO)
+#define TOTAL_ANALOG_PINS       6
+#define TOTAL_PINS              15 // 9 digital + 3 analog
+#define IS_PIN_DIGITAL(p)       ((p) >= 2 && (p) <= 14)
+#define IS_PIN_ANALOG(p)        ((p) == 8 || (p) == 9 || (p) == 10 || (p) == 11 || (p) == 12 || (p) == 14) //A0~A5
+#define IS_PIN_PWM(p)           ((p) == 3 || (p) == 5 || (p) == 6)
+#define IS_PIN_SERVO(p)         ((p) >= 2 && (p) <= 7)
+#define IS_PIN_I2C(p)           ((p) == SDA || (p) == SCL)
+#define IS_PIN_SPI(p)           ((p) == CS || (p) == MOSI || (p) == MISO || (p) == SCK)
+#define PIN_TO_DIGITAL(p)       (p)
+#define PIN_TO_ANALOG(p)        ((p) - 8)
+#define PIN_TO_PWM(p)           PIN_TO_DIGITAL(p)
+#define PIN_TO_SERVO(p)         (p)
+
+
 // Sanguino
 #elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644__)
 #define TOTAL_ANALOG_PINS       8

--- a/Firmata.cpp
+++ b/Firmata.cpp
@@ -33,8 +33,8 @@ extern "C" {
  */
 void FirmataClass::sendValueAsTwo7bitBytes(int value)
 {
-  FirmataStream->write(value & B01111111); // LSB
-  FirmataStream->write(value >> 7 & B01111111); // MSB
+  FirmataStream->write(value & 0x7F); // LSB
+  FirmataStream->write(value >> 7 & 0x7F); // MSB
 }
 
 /**

--- a/examples/StandardFirmataBLE/LICENSE.txt
+++ b/examples/StandardFirmataBLE/LICENSE.txt
@@ -1,0 +1,458 @@
+
+		  GNU LESSER GENERAL PUBLIC LICENSE
+		       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+		  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+  
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+			    NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+

--- a/examples/StandardFirmataBLE/StandardFirmataBLE.ino
+++ b/examples/StandardFirmataBLE/StandardFirmataBLE.ino
@@ -1,0 +1,780 @@
+/*
+  Firmata is a generic protocol for communicating with microcontrollers
+  from software on a host computer. It is intended to work with
+  any host computer software package.
+
+  To download a host software package, please clink on the following link
+  to open the list of Firmata client libraries your default browser.
+
+  https://github.com/firmata/arduino#firmata-client-libraries
+
+  Copyright (C) 2006-2008 Hans-Christoph Steiner.  All rights reserved.
+  Copyright (C) 2010-2011 Paul Stoffregen.  All rights reserved.
+  Copyright (C) 2009 Shigeru Kobayashi.  All rights reserved.
+  Copyright (C) 2009-2015 Jeff Hoefs.  All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  See file LICENSE.txt for further informations on licensing terms.
+
+  Last updated by Jeff Hoefs: December 26th, 2015
+*/
+
+#include <Servo.h>
+#include <Wire.h>
+#include <Firmata.h>
+
+#include <CurieBle.h>
+#include "utility/BLEStream.h"
+
+#define I2C_WRITE                   B00000000
+#define I2C_READ                    B00001000
+#define I2C_READ_CONTINUOUSLY       B00010000
+#define I2C_STOP_READING            B00011000
+#define I2C_READ_WRITE_MODE_MASK    B00011000
+#define I2C_10BIT_ADDRESS_MODE_MASK B00100000
+#define I2C_END_TX_MASK             B01000000
+#define I2C_STOP_TX                 1
+#define I2C_RESTART_TX              0
+#define I2C_MAX_QUERIES             8
+#define I2C_REGISTER_NOT_SPECIFIED  -1
+
+// the minimum interval for sampling analog input
+#define MINIMUM_SAMPLING_INTERVAL   1
+
+
+/*==============================================================================
+ * GLOBAL VARIABLES
+ *============================================================================*/
+
+/* analog inputs */
+int analogInputsToReport = 0; // bitwise array to store pin reporting
+
+/* digital input ports */
+byte reportPINs[TOTAL_PORTS];       // 1 = report this port, 0 = silence
+byte previousPINs[TOTAL_PORTS];     // previous 8 bits sent
+
+/* pins configuration */
+byte pinConfig[TOTAL_PINS];         // configuration of every pin
+byte portConfigInputs[TOTAL_PORTS]; // each bit: 1 = pin in INPUT, 0 = anything else
+int pinState[TOTAL_PINS];           // any value that has been written
+
+/* timer variables */
+unsigned long currentMillis;        // store the current value from millis()
+unsigned long previousMillis;       // for comparison with currentMillis
+unsigned int samplingInterval = 19; // how often to run the main loop (in ms)
+
+/* i2c data */
+struct i2c_device_info {
+  byte addr;
+  int reg;
+  byte bytes;
+  byte stopTX;
+};
+
+/* for i2c read continuous more */
+i2c_device_info query[I2C_MAX_QUERIES];
+
+byte i2cRxData[32];
+boolean isI2CEnabled = false;
+signed char queryIndex = -1;
+// default delay time between i2c read request and Wire.requestFrom()
+unsigned int i2cReadDelayTime = 0;
+
+Servo servos[MAX_SERVOS];
+byte servoPinMap[TOTAL_PINS];
+byte detachedServos[MAX_SERVOS];
+byte detachedServoCount = 0;
+byte servoCount = 0;
+
+boolean isResetting = false;
+
+BLEStream stream(0);
+
+/* utility functions */
+void wireWrite(byte data)
+{
+#if ARDUINO >= 100
+  Wire.write((byte)data);
+#else
+  Wire.send(data);
+#endif
+}
+
+byte wireRead(void)
+{
+#if ARDUINO >= 100
+  return Wire.read();
+#else
+  return Wire.receive();
+#endif
+}
+
+/*==============================================================================
+ * FUNCTIONS
+ *============================================================================*/
+
+void attachServo(byte pin, int minPulse, int maxPulse)
+{
+  if (servoCount < MAX_SERVOS) {
+    // reuse indexes of detached servos until all have been reallocated
+    if (detachedServoCount > 0) {
+      servoPinMap[pin] = detachedServos[detachedServoCount - 1];
+      if (detachedServoCount > 0) detachedServoCount--;
+    } else {
+      servoPinMap[pin] = servoCount;
+      servoCount++;
+    }
+    if (minPulse > 0 && maxPulse > 0) {
+      servos[servoPinMap[pin]].attach(PIN_TO_DIGITAL(pin), minPulse, maxPulse);
+    } else {
+      servos[servoPinMap[pin]].attach(PIN_TO_DIGITAL(pin));
+    }
+  } else {
+    Firmata.sendString("Max servos attached");
+  }
+}
+
+void detachServo(byte pin)
+{
+  servos[servoPinMap[pin]].detach();
+  // if we're detaching the last servo, decrement the count
+  // otherwise store the index of the detached servo
+  if (servoPinMap[pin] == servoCount && servoCount > 0) {
+    servoCount--;
+  } else if (servoCount > 0) {
+    // keep track of detached servos because we want to reuse their indexes
+    // before incrementing the count of attached servos
+    detachedServoCount++;
+    detachedServos[detachedServoCount - 1] = servoPinMap[pin];
+  }
+
+  servoPinMap[pin] = 255;
+}
+
+void readAndReportData(byte address, int theRegister, byte numBytes, byte stopTX) {
+  // allow I2C requests that don't require a register read
+  // for example, some devices using an interrupt pin to signify new data available
+  // do not always require the register read so upon interrupt you call Wire.requestFrom()
+  if (theRegister != I2C_REGISTER_NOT_SPECIFIED) {
+    Wire.beginTransmission(address);
+    wireWrite((byte)theRegister);
+    Wire.endTransmission(stopTX); // default = true
+    // do not set a value of 0
+    if (i2cReadDelayTime > 0) {
+      // delay is necessary for some devices such as WiiNunchuck
+      delayMicroseconds(i2cReadDelayTime);
+    }
+  } else {
+    theRegister = 0;  // fill the register with a dummy value
+  }
+
+  Wire.requestFrom(address, numBytes);  // all bytes are returned in requestFrom
+
+  // check to be sure correct number of bytes were returned by slave
+  if (numBytes < Wire.available()) {
+    Firmata.sendString("I2C: Too many bytes received");
+  } else if (numBytes > Wire.available()) {
+    Firmata.sendString("I2C: Too few bytes received");
+  }
+
+  i2cRxData[0] = address;
+  i2cRxData[1] = theRegister;
+
+  for (int i = 0; i < numBytes && Wire.available(); i++) {
+    i2cRxData[2 + i] = wireRead();
+  }
+
+  // send slave address, register and received bytes
+  Firmata.sendSysex(SYSEX_I2C_REPLY, numBytes + 2, i2cRxData);
+}
+
+void outputPort(byte portNumber, byte portValue, byte forceSend)
+{
+  // pins not configured as INPUT are cleared to zeros
+  portValue = portValue & portConfigInputs[portNumber];
+  // only send if the value is different than previously sent
+  if (forceSend || previousPINs[portNumber] != portValue) {
+    Firmata.sendDigitalPort(portNumber, portValue);
+    previousPINs[portNumber] = portValue;
+  }
+}
+
+/* -----------------------------------------------------------------------------
+ * check all the active digital inputs for change of state, then add any events
+ * to the Serial output queue using Serial.print() */
+void checkDigitalInputs(void)
+{
+  /* Using non-looping code allows constants to be given to readPort().
+   * The compiler will apply substantial optimizations if the inputs
+   * to readPort() are compile-time constants. */
+  if (TOTAL_PORTS > 0 && reportPINs[0]) outputPort(0, readPort(0, portConfigInputs[0]), false);
+  if (TOTAL_PORTS > 1 && reportPINs[1]) outputPort(1, readPort(1, portConfigInputs[1]), false);
+  if (TOTAL_PORTS > 2 && reportPINs[2]) outputPort(2, readPort(2, portConfigInputs[2]), false);
+  if (TOTAL_PORTS > 3 && reportPINs[3]) outputPort(3, readPort(3, portConfigInputs[3]), false);
+  if (TOTAL_PORTS > 4 && reportPINs[4]) outputPort(4, readPort(4, portConfigInputs[4]), false);
+  if (TOTAL_PORTS > 5 && reportPINs[5]) outputPort(5, readPort(5, portConfigInputs[5]), false);
+  if (TOTAL_PORTS > 6 && reportPINs[6]) outputPort(6, readPort(6, portConfigInputs[6]), false);
+  if (TOTAL_PORTS > 7 && reportPINs[7]) outputPort(7, readPort(7, portConfigInputs[7]), false);
+  if (TOTAL_PORTS > 8 && reportPINs[8]) outputPort(8, readPort(8, portConfigInputs[8]), false);
+  if (TOTAL_PORTS > 9 && reportPINs[9]) outputPort(9, readPort(9, portConfigInputs[9]), false);
+  if (TOTAL_PORTS > 10 && reportPINs[10]) outputPort(10, readPort(10, portConfigInputs[10]), false);
+  if (TOTAL_PORTS > 11 && reportPINs[11]) outputPort(11, readPort(11, portConfigInputs[11]), false);
+  if (TOTAL_PORTS > 12 && reportPINs[12]) outputPort(12, readPort(12, portConfigInputs[12]), false);
+  if (TOTAL_PORTS > 13 && reportPINs[13]) outputPort(13, readPort(13, portConfigInputs[13]), false);
+  if (TOTAL_PORTS > 14 && reportPINs[14]) outputPort(14, readPort(14, portConfigInputs[14]), false);
+  if (TOTAL_PORTS > 15 && reportPINs[15]) outputPort(15, readPort(15, portConfigInputs[15]), false);
+}
+
+// -----------------------------------------------------------------------------
+/* sets the pin mode to the correct state and sets the relevant bits in the
+ * two bit-arrays that track Digital I/O and PWM status
+ */
+void setPinModeCallback(byte pin, int mode)
+{
+  if (pinConfig[pin] == PIN_MODE_IGNORE)
+    return;
+
+  if (pinConfig[pin] == PIN_MODE_I2C && isI2CEnabled && mode != PIN_MODE_I2C) {
+    // disable i2c so pins can be used for other functions
+    // the following if statements should reconfigure the pins properly
+    disableI2CPins();
+  }
+  if (IS_PIN_DIGITAL(pin) && mode != PIN_MODE_SERVO) {
+    if (servoPinMap[pin] < MAX_SERVOS && servos[servoPinMap[pin]].attached()) {
+      detachServo(pin);
+    }
+  }
+  if (IS_PIN_ANALOG(pin)) {
+    reportAnalogCallback(PIN_TO_ANALOG(pin), mode == PIN_MODE_ANALOG ? 1 : 0); // turn on/off reporting
+  }
+  if (IS_PIN_DIGITAL(pin)) {
+    if (mode == INPUT || mode == PIN_MODE_PULLUP) {
+      portConfigInputs[pin / 8] |= (1 << (pin & 7));
+    } else {
+      portConfigInputs[pin / 8] &= ~(1 << (pin & 7));
+    }
+  }
+  pinState[pin] = 0;
+  switch (mode) {
+    case PIN_MODE_ANALOG:
+      if (IS_PIN_ANALOG(pin)) {
+        if (IS_PIN_DIGITAL(pin)) {
+          pinMode(PIN_TO_DIGITAL(pin), INPUT);    // disable output driver
+#if ARDUINO <= 100
+          // deprecated since Arduino 1.0.1 - TODO: drop support in Firmata 2.6
+          digitalWrite(PIN_TO_DIGITAL(pin), LOW); // disable internal pull-ups
+#endif
+        }
+        pinConfig[pin] = PIN_MODE_ANALOG;
+      }
+      break;
+    case INPUT:
+      if (IS_PIN_DIGITAL(pin)) {
+        pinMode(PIN_TO_DIGITAL(pin), INPUT);    // disable output driver
+#if ARDUINO <= 100
+        // deprecated since Arduino 1.0.1 - TODO: drop support in Firmata 2.6
+        digitalWrite(PIN_TO_DIGITAL(pin), LOW); // disable internal pull-ups
+#endif
+        pinConfig[pin] = INPUT;
+      }
+      break;
+    case PIN_MODE_PULLUP:
+      if (IS_PIN_DIGITAL(pin)) {
+        pinMode(PIN_TO_DIGITAL(pin), INPUT_PULLUP);
+        pinConfig[pin] = PIN_MODE_PULLUP;
+        pinState[pin] = 1;
+      }
+      break;
+    case OUTPUT:
+      if (IS_PIN_DIGITAL(pin)) {
+        digitalWrite(PIN_TO_DIGITAL(pin), LOW); // disable PWM
+        pinMode(PIN_TO_DIGITAL(pin), OUTPUT);
+        pinConfig[pin] = OUTPUT;
+      }
+      break;
+    case PIN_MODE_PWM:
+      if (IS_PIN_PWM(pin)) {
+        pinMode(PIN_TO_PWM(pin), OUTPUT);
+        analogWrite(PIN_TO_PWM(pin), 0);
+        pinConfig[pin] = PIN_MODE_PWM;
+      }
+      break;
+    case PIN_MODE_SERVO:
+      if (IS_PIN_DIGITAL(pin)) {
+        pinConfig[pin] = PIN_MODE_SERVO;
+        if (servoPinMap[pin] == 255 || !servos[servoPinMap[pin]].attached()) {
+          // pass -1 for min and max pulse values to use default values set
+          // by Servo library
+          attachServo(pin, -1, -1);
+        }
+      }
+      break;
+    case PIN_MODE_I2C:
+      if (IS_PIN_I2C(pin)) {
+        // mark the pin as i2c
+        // the user must call I2C_CONFIG to enable I2C for a device
+        pinConfig[pin] = PIN_MODE_I2C;
+      }
+      break;
+    default:
+      Firmata.sendString("Unknown pin mode"); // TODO: put error msgs in EEPROM
+  }
+  // TODO: save status to EEPROM here, if changed
+}
+
+/*
+ * Sets the value of an individual pin. Useful if you want to set a pin value but
+ * are not tracking the digital port state.
+ * Can only be used on pins configured as OUTPUT.
+ * Cannot be used to enable pull-ups on Digital INPUT pins.
+ */
+void setPinValueCallback(byte pin, int value)
+{
+  if (pin < TOTAL_PINS && IS_PIN_DIGITAL(pin)) {
+    if (pinConfig[pin] == OUTPUT) {
+      pinState[pin] = value;
+      digitalWrite(PIN_TO_DIGITAL(pin), value);
+    }
+  }
+}
+
+void analogWriteCallback(byte pin, int value)
+{
+  if (pin < TOTAL_PINS) {
+    switch (pinConfig[pin]) {
+      case PIN_MODE_SERVO:
+        if (IS_PIN_DIGITAL(pin))
+          servos[servoPinMap[pin]].write(value);
+        pinState[pin] = value;
+        break;
+      case PIN_MODE_PWM:
+        if (IS_PIN_PWM(pin))
+          analogWrite(PIN_TO_PWM(pin), value);
+        pinState[pin] = value;
+        break;
+    }
+  }
+}
+
+void digitalWriteCallback(byte port, int value)
+{
+  byte pin, lastPin, pinValue, mask = 1, pinWriteMask = 0;
+
+  if (port < TOTAL_PORTS) {
+    // create a mask of the pins on this port that are writable.
+    lastPin = port * 8 + 8;
+    if (lastPin > TOTAL_PINS) lastPin = TOTAL_PINS;
+    for (pin = port * 8; pin < lastPin; pin++) {
+      // do not disturb non-digital pins (eg, Rx & Tx)
+      if (IS_PIN_DIGITAL(pin)) {
+        // do not touch pins in PWM, ANALOG, SERVO or other modes
+        if (pinConfig[pin] == OUTPUT || pinConfig[pin] == INPUT) {
+          pinValue = ((byte)value & mask) ? 1 : 0;
+          if (pinConfig[pin] == OUTPUT) {
+            pinWriteMask |= mask;
+          } else if (pinConfig[pin] == INPUT && pinValue == 1 && pinState[pin] != 1) {
+            // only handle INPUT here for backwards compatibility
+#if ARDUINO > 100
+            pinMode(pin, INPUT_PULLUP);
+#else
+            // only write to the INPUT pin to enable pullups if Arduino v1.0.0 or earlier
+            pinWriteMask |= mask;
+#endif
+          }
+          pinState[pin] = pinValue;
+        }
+      }
+      mask = mask << 1;
+    }
+    writePort(port, (byte)value, pinWriteMask);
+  }
+}
+
+
+// -----------------------------------------------------------------------------
+/* sets bits in a bit array (int) to toggle the reporting of the analogIns
+ */
+//void FirmataClass::setAnalogPinReporting(byte pin, byte state) {
+//}
+void reportAnalogCallback(byte analogPin, int value)
+{
+  if (analogPin < TOTAL_ANALOG_PINS) {
+    if (value == 0) {
+      analogInputsToReport = analogInputsToReport & ~ (1 << analogPin);
+    } else {
+      analogInputsToReport = analogInputsToReport | (1 << analogPin);
+      // prevent during system reset or all analog pin values will be reported
+      // which may report noise for unconnected analog pins
+      if (!isResetting) {
+        // Send pin value immediately. This is helpful when connected via
+        // ethernet, wi-fi or bluetooth so pin states can be known upon
+        // reconnecting.
+        Firmata.sendAnalog(analogPin, analogRead(analogPin));
+      }
+    }
+  }
+  // TODO: save status to EEPROM here, if changed
+}
+
+void reportDigitalCallback(byte port, int value)
+{
+  if (port < TOTAL_PORTS) {
+    reportPINs[port] = (byte)value;
+    // Send port value immediately. This is helpful when connected via
+    // ethernet, wi-fi or bluetooth so pin states can be known upon
+    // reconnecting.
+    if (value) outputPort(port, readPort(port, portConfigInputs[port]), true);
+  }
+  // do not disable analog reporting on these 8 pins, to allow some
+  // pins used for digital, others analog.  Instead, allow both types
+  // of reporting to be enabled, but check if the pin is configured
+  // as analog when sampling the analog inputs.  Likewise, while
+  // scanning digital pins, portConfigInputs will mask off values from any
+  // pins configured as analog
+}
+
+/*==============================================================================
+ * SYSEX-BASED commands
+ *============================================================================*/
+
+void sysexCallback(byte command, byte argc, byte *argv)
+{
+  byte mode;
+  byte stopTX;
+  byte slaveAddress;
+  byte data;
+  int slaveRegister;
+  unsigned int delayTime;
+
+  switch (command) {
+    case I2C_REQUEST:
+      mode = argv[1] & I2C_READ_WRITE_MODE_MASK;
+      if (argv[1] & I2C_10BIT_ADDRESS_MODE_MASK) {
+        Firmata.sendString("10-bit addressing not supported");
+        return;
+      }
+      else {
+        slaveAddress = argv[0];
+      }
+
+      // need to invert the logic here since 0 will be default for client
+      // libraries that have not updated to add support for restart tx
+      if (argv[1] & I2C_END_TX_MASK) {
+        stopTX = I2C_RESTART_TX;
+      }
+      else {
+        stopTX = I2C_STOP_TX; // default
+      }
+
+      switch (mode) {
+        case I2C_WRITE:
+          Wire.beginTransmission(slaveAddress);
+          for (byte i = 2; i < argc; i += 2) {
+            data = argv[i] + (argv[i + 1] << 7);
+            wireWrite(data);
+          }
+          Wire.endTransmission();
+          delayMicroseconds(70);
+          break;
+        case I2C_READ:
+          if (argc == 6) {
+            // a slave register is specified
+            slaveRegister = argv[2] + (argv[3] << 7);
+            data = argv[4] + (argv[5] << 7);  // bytes to read
+          }
+          else {
+            // a slave register is NOT specified
+            slaveRegister = I2C_REGISTER_NOT_SPECIFIED;
+            data = argv[2] + (argv[3] << 7);  // bytes to read
+          }
+          readAndReportData(slaveAddress, (int)slaveRegister, data, stopTX);
+          break;
+        case I2C_READ_CONTINUOUSLY:
+          if ((queryIndex + 1) >= I2C_MAX_QUERIES) {
+            // too many queries, just ignore
+            Firmata.sendString("too many queries");
+            break;
+          }
+          if (argc == 6) {
+            // a slave register is specified
+            slaveRegister = argv[2] + (argv[3] << 7);
+            data = argv[4] + (argv[5] << 7);  // bytes to read
+          }
+          else {
+            // a slave register is NOT specified
+            slaveRegister = (int)I2C_REGISTER_NOT_SPECIFIED;
+            data = argv[2] + (argv[3] << 7);  // bytes to read
+          }
+          queryIndex++;
+          query[queryIndex].addr = slaveAddress;
+          query[queryIndex].reg = slaveRegister;
+          query[queryIndex].bytes = data;
+          query[queryIndex].stopTX = stopTX;
+          break;
+        case I2C_STOP_READING:
+          byte queryIndexToSkip;
+          // if read continuous mode is enabled for only 1 i2c device, disable
+          // read continuous reporting for that device
+          if (queryIndex <= 0) {
+            queryIndex = -1;
+          } else {
+            queryIndexToSkip = 0;
+            // if read continuous mode is enabled for multiple devices,
+            // determine which device to stop reading and remove it's data from
+            // the array, shifiting other array data to fill the space
+            for (byte i = 0; i < queryIndex + 1; i++) {
+              if (query[i].addr == slaveAddress) {
+                queryIndexToSkip = i;
+                break;
+              }
+            }
+
+            for (byte i = queryIndexToSkip; i < queryIndex + 1; i++) {
+              if (i < I2C_MAX_QUERIES) {
+                query[i].addr = query[i + 1].addr;
+                query[i].reg = query[i + 1].reg;
+                query[i].bytes = query[i + 1].bytes;
+                query[i].stopTX = query[i + 1].stopTX;
+              }
+            }
+            queryIndex--;
+          }
+          break;
+        default:
+          break;
+      }
+      break;
+    case I2C_CONFIG:
+      delayTime = (argv[0] + (argv[1] << 7));
+
+      if (delayTime > 0) {
+        i2cReadDelayTime = delayTime;
+      }
+
+      if (!isI2CEnabled) {
+        enableI2CPins();
+      }
+
+      break;
+    case SERVO_CONFIG:
+      if (argc > 4) {
+        // these vars are here for clarity, they'll optimized away by the compiler
+        byte pin = argv[0];
+        int minPulse = argv[1] + (argv[2] << 7);
+        int maxPulse = argv[3] + (argv[4] << 7);
+
+        if (IS_PIN_DIGITAL(pin)) {
+          if (servoPinMap[pin] < MAX_SERVOS && servos[servoPinMap[pin]].attached()) {
+            detachServo(pin);
+          }
+          attachServo(pin, minPulse, maxPulse);
+          setPinModeCallback(pin, PIN_MODE_SERVO);
+        }
+      }
+      break;
+    case SAMPLING_INTERVAL:
+      if (argc > 1) {
+        samplingInterval = argv[0] + (argv[1] << 7);
+        if (samplingInterval < MINIMUM_SAMPLING_INTERVAL) {
+          samplingInterval = MINIMUM_SAMPLING_INTERVAL;
+        }
+      } else {
+        //Firmata.sendString("Not enough data");
+      }
+      break;
+    case EXTENDED_ANALOG:
+      if (argc > 1) {
+        int val = argv[1];
+        if (argc > 2) val |= (argv[2] << 7);
+        if (argc > 3) val |= (argv[3] << 14);
+        analogWriteCallback(argv[0], val);
+      }
+      break;
+    case CAPABILITY_QUERY:
+      Firmata.write(START_SYSEX);
+      Firmata.write(CAPABILITY_RESPONSE);
+      for (byte pin = 0; pin < TOTAL_PINS; pin++) {
+        if (IS_PIN_DIGITAL(pin)) {
+          Firmata.write((byte)INPUT);
+          Firmata.write(1);
+          Firmata.write((byte)PIN_MODE_PULLUP);
+          Firmata.write(1);
+          Firmata.write((byte)OUTPUT);
+          Firmata.write(1);
+        }
+        if (IS_PIN_ANALOG(pin)) {
+          Firmata.write(PIN_MODE_ANALOG);
+          Firmata.write(10); // 10 = 10-bit resolution
+        }
+        if (IS_PIN_PWM(pin)) {
+          Firmata.write(PIN_MODE_PWM);
+          Firmata.write(8); // 8 = 8-bit resolution
+        }
+        if (IS_PIN_DIGITAL(pin)) {
+          Firmata.write(PIN_MODE_SERVO);
+          Firmata.write(14);
+        }
+        if (IS_PIN_I2C(pin)) {
+          Firmata.write(PIN_MODE_I2C);
+          Firmata.write(1);  // TODO: could assign a number to map to SCL or SDA
+        }
+        Firmata.write(127);
+      }
+      Firmata.write(END_SYSEX);
+      break;
+    case PIN_STATE_QUERY:
+      if (argc > 0) {
+        byte pin = argv[0];
+        Firmata.write(START_SYSEX);
+        Firmata.write(PIN_STATE_RESPONSE);
+        Firmata.write(pin);
+        if (pin < TOTAL_PINS) {
+          Firmata.write((byte)pinConfig[pin]);
+          Firmata.write((byte)pinState[pin] & 0x7F);
+          if (pinState[pin] & 0xFF80) Firmata.write((byte)(pinState[pin] >> 7) & 0x7F);
+          if (pinState[pin] & 0xC000) Firmata.write((byte)(pinState[pin] >> 14) & 0x7F);
+        }
+        Firmata.write(END_SYSEX);
+      }
+      break;
+    case ANALOG_MAPPING_QUERY:
+      Firmata.write(START_SYSEX);
+      Firmata.write(ANALOG_MAPPING_RESPONSE);
+      for (byte pin = 0; pin < TOTAL_PINS; pin++) {
+        Firmata.write(IS_PIN_ANALOG(pin) ? PIN_TO_ANALOG(pin) : 127);
+      }
+      Firmata.write(END_SYSEX);
+      break;
+  }
+}
+
+void enableI2CPins()
+{
+  byte i;
+  // is there a faster way to do this? would probaby require importing
+  // Arduino.h to get SCL and SDA pins
+  for (i = 0; i < TOTAL_PINS; i++) {
+    if (IS_PIN_I2C(i)) {
+      // mark pins as i2c so they are ignore in non i2c data requests
+      setPinModeCallback(i, PIN_MODE_I2C);
+    }
+  }
+
+  isI2CEnabled = true;
+
+  Wire.begin();
+}
+
+/* disable the i2c pins so they can be used for other functions */
+void disableI2CPins() {
+  isI2CEnabled = false;
+  // disable read continuous mode for all devices
+  queryIndex = -1;
+}
+
+/*==============================================================================
+ * SETUP()
+ *============================================================================*/
+
+void systemResetCallback()
+{
+  isResetting = true;
+
+  if (isI2CEnabled) {
+    disableI2CPins();
+  }
+
+  for (byte i = 0; i < TOTAL_PORTS; i++) {
+    reportPINs[i] = false;    // by default, reporting off
+    portConfigInputs[i] = 0;  // until activated
+    previousPINs[i] = 0;
+  }
+
+  for (byte i = 0; i < TOTAL_PINS; i++) {
+    // pins with analog capability default to analog input
+    // otherwise, pins default to digital output
+    if (IS_PIN_ANALOG(i)) {
+      // turns off pullup, configures everything
+      setPinModeCallback(i, PIN_MODE_ANALOG);
+    } else if (IS_PIN_DIGITAL(i)) {
+      // sets the output to 0, configures portConfigInputs
+      setPinModeCallback(i, OUTPUT);
+    }
+
+    servoPinMap[i] = 255;
+  }
+  // by default, do not report any analog inputs
+  analogInputsToReport = 0;
+
+  detachedServoCount = 0;
+  servoCount = 0;
+
+  isResetting = false;
+}
+
+void setup()
+{
+  Firmata.setFirmwareVersion(FIRMATA_FIRMWARE_MAJOR_VERSION, FIRMATA_FIRMWARE_MINOR_VERSION);
+
+  Firmata.attach(ANALOG_MESSAGE, analogWriteCallback);
+  Firmata.attach(DIGITAL_MESSAGE, digitalWriteCallback);
+  Firmata.attach(REPORT_ANALOG, reportAnalogCallback);
+  Firmata.attach(REPORT_DIGITAL, reportDigitalCallback);
+  Firmata.attach(SET_PIN_MODE, setPinModeCallback);
+  Firmata.attach(SET_DIGITAL_PIN_VALUE, setPinValueCallback);
+  Firmata.attach(START_SYSEX, sysexCallback);
+  Firmata.attach(SYSTEM_RESET, systemResetCallback);
+
+  stream.setLocalName("FIRMATA");
+
+  stream.begin();
+  Firmata.begin(stream);
+
+  systemResetCallback();  // reset to default config
+}
+
+/*==============================================================================
+ * LOOP()
+ *============================================================================*/
+void loop()
+{
+  byte pin, analogPin;
+
+  // do not process data if no BLE connection is established
+  if (!stream.poll()) return;
+
+  /* DIGITALREAD - as fast as possible, check for changes and output them to the
+   * Stream buffer using Stream.write()  */
+  checkDigitalInputs();
+  //stream.flush(); // send digital input values immediately
+
+  /* STREAMREAD - processing incoming messagse as soon as possible, while still
+   * checking digital inputs.  */
+  while (Firmata.available())
+    Firmata.processInput();
+
+  currentMillis = millis();
+  if (currentMillis - previousMillis > samplingInterval) {
+    previousMillis += samplingInterval;
+    /* ANALOGREAD - do all analogReads() at the configured sampling interval */
+    for (pin = 0; pin < TOTAL_PINS; pin++) {
+      if (IS_PIN_ANALOG(pin) && pinConfig[pin] == PIN_MODE_ANALOG) {
+        analogPin = PIN_TO_ANALOG(pin);
+        if (analogInputsToReport & (1 << analogPin)) {
+          Firmata.sendAnalog(analogPin, analogRead(analogPin));
+        }
+      }
+    }
+    // report i2c data for all device with read continuous mode enabled
+    if (queryIndex > -1) {
+      for (byte i = 0; i < queryIndex + 1; i++) {
+        readAndReportData(query[i].addr, query[i].reg, query[i].bytes, query[i].stopTX);
+      }
+    }
+    //stream.flush();
+  }
+}

--- a/examples/StandardFirmataBLE/StandardFirmataBLE.ino
+++ b/examples/StandardFirmataBLE/StandardFirmataBLE.ino
@@ -20,7 +20,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated by Jeff Hoefs: February 20th, 2016
+  Last updated by Jeff Hoefs: February 27th, 2016
 */
 
 #include <Servo.h>
@@ -52,6 +52,10 @@
  * GLOBAL VARIABLES
  *============================================================================*/
 
+#ifdef FIRMATA_SERIAL_FEATURE
+SerialFirmata serialFeature;
+#endif
+
 /* analog inputs */
 int analogInputsToReport = 0; // bitwise array to store pin reporting
 
@@ -60,9 +64,7 @@ byte reportPINs[TOTAL_PORTS];       // 1 = report this port, 0 = silence
 byte previousPINs[TOTAL_PORTS];     // previous 8 bits sent
 
 /* pins configuration */
-byte pinConfig[TOTAL_PINS];         // configuration of every pin
 byte portConfigInputs[TOTAL_PORTS]; // each bit: 1 = pin in INPUT, 0 = anything else
-int pinState[TOTAL_PINS];           // any value that has been written
 
 /* timer variables */
 unsigned long currentMillis;        // store the current value from millis()
@@ -235,10 +237,10 @@ void checkDigitalInputs(void)
  */
 void setPinModeCallback(byte pin, int mode)
 {
-  if (pinConfig[pin] == PIN_MODE_IGNORE)
+  if (Firmata.getPinMode(pin) == PIN_MODE_IGNORE)
     return;
 
-  if (pinConfig[pin] == PIN_MODE_I2C && isI2CEnabled && mode != PIN_MODE_I2C) {
+  if (Firmata.getPinMode(pin) == PIN_MODE_I2C && isI2CEnabled && mode != PIN_MODE_I2C) {
     // disable i2c so pins can be used for other functions
     // the following if statements should reconfigure the pins properly
     disableI2CPins();
@@ -258,7 +260,7 @@ void setPinModeCallback(byte pin, int mode)
       portConfigInputs[pin / 8] &= ~(1 << (pin & 7));
     }
   }
-  pinState[pin] = 0;
+  Firmata.setPinState(pin, 0);
   switch (mode) {
     case PIN_MODE_ANALOG:
       if (IS_PIN_ANALOG(pin)) {
@@ -269,7 +271,7 @@ void setPinModeCallback(byte pin, int mode)
           digitalWrite(PIN_TO_DIGITAL(pin), LOW); // disable internal pull-ups
 #endif
         }
-        pinConfig[pin] = PIN_MODE_ANALOG;
+        Firmata.setPinMode(pin, PIN_MODE_ANALOG);
       }
       break;
     case INPUT:
@@ -279,33 +281,33 @@ void setPinModeCallback(byte pin, int mode)
         // deprecated since Arduino 1.0.1 - TODO: drop support in Firmata 2.6
         digitalWrite(PIN_TO_DIGITAL(pin), LOW); // disable internal pull-ups
 #endif
-        pinConfig[pin] = INPUT;
+        Firmata.setPinMode(pin, INPUT);
       }
       break;
     case PIN_MODE_PULLUP:
       if (IS_PIN_DIGITAL(pin)) {
         pinMode(PIN_TO_DIGITAL(pin), INPUT_PULLUP);
-        pinConfig[pin] = PIN_MODE_PULLUP;
-        pinState[pin] = 1;
+        Firmata.setPinMode(pin, PIN_MODE_PULLUP);
+        Firmata.setPinState(pin, 1);
       }
       break;
     case OUTPUT:
       if (IS_PIN_DIGITAL(pin)) {
         digitalWrite(PIN_TO_DIGITAL(pin), LOW); // disable PWM
         pinMode(PIN_TO_DIGITAL(pin), OUTPUT);
-        pinConfig[pin] = OUTPUT;
+        Firmata.setPinMode(pin, OUTPUT);
       }
       break;
     case PIN_MODE_PWM:
       if (IS_PIN_PWM(pin)) {
         pinMode(PIN_TO_PWM(pin), OUTPUT);
         analogWrite(PIN_TO_PWM(pin), 0);
-        pinConfig[pin] = PIN_MODE_PWM;
+        Firmata.setPinMode(pin, PIN_MODE_PWM);
       }
       break;
     case PIN_MODE_SERVO:
       if (IS_PIN_DIGITAL(pin)) {
-        pinConfig[pin] = PIN_MODE_SERVO;
+        Firmata.setPinMode(pin, PIN_MODE_SERVO);
         if (servoPinMap[pin] == 255 || !servos[servoPinMap[pin]].attached()) {
           // pass -1 for min and max pulse values to use default values set
           // by Servo library
@@ -317,8 +319,13 @@ void setPinModeCallback(byte pin, int mode)
       if (IS_PIN_I2C(pin)) {
         // mark the pin as i2c
         // the user must call I2C_CONFIG to enable I2C for a device
-        pinConfig[pin] = PIN_MODE_I2C;
+        Firmata.setPinMode(pin, PIN_MODE_I2C);
       }
+      break;
+    case PIN_MODE_SERIAL:
+#ifdef FIRMATA_SERIAL_FEATURE
+      serialFeature.handlePinMode(pin, PIN_MODE_SERIAL);
+#endif
       break;
     default:
       Firmata.sendString("Unknown pin mode"); // TODO: put error msgs in EEPROM
@@ -335,8 +342,8 @@ void setPinModeCallback(byte pin, int mode)
 void setPinValueCallback(byte pin, int value)
 {
   if (pin < TOTAL_PINS && IS_PIN_DIGITAL(pin)) {
-    if (pinConfig[pin] == OUTPUT) {
-      pinState[pin] = value;
+    if (Firmata.getPinMode(pin) == OUTPUT) {
+      Firmata.setPinState(pin, value);
       digitalWrite(PIN_TO_DIGITAL(pin), value);
     }
   }
@@ -345,16 +352,16 @@ void setPinValueCallback(byte pin, int value)
 void analogWriteCallback(byte pin, int value)
 {
   if (pin < TOTAL_PINS) {
-    switch (pinConfig[pin]) {
+    switch (Firmata.getPinMode(pin)) {
       case PIN_MODE_SERVO:
         if (IS_PIN_DIGITAL(pin))
           servos[servoPinMap[pin]].write(value);
-        pinState[pin] = value;
+        Firmata.setPinState(pin, value);
         break;
       case PIN_MODE_PWM:
         if (IS_PIN_PWM(pin))
           analogWrite(PIN_TO_PWM(pin), value);
-        pinState[pin] = value;
+        Firmata.setPinState(pin, value);
         break;
     }
   }
@@ -372,11 +379,11 @@ void digitalWriteCallback(byte port, int value)
       // do not disturb non-digital pins (eg, Rx & Tx)
       if (IS_PIN_DIGITAL(pin)) {
         // do not touch pins in PWM, ANALOG, SERVO or other modes
-        if (pinConfig[pin] == OUTPUT || pinConfig[pin] == INPUT) {
+        if (Firmata.getPinMode(pin) == OUTPUT || Firmata.getPinMode(pin) == INPUT) {
           pinValue = ((byte)value & mask) ? 1 : 0;
-          if (pinConfig[pin] == OUTPUT) {
+          if (Firmata.getPinMode(pin) == OUTPUT) {
             pinWriteMask |= mask;
-          } else if (pinConfig[pin] == INPUT && pinValue == 1 && pinState[pin] != 1) {
+          } else if (Firmata.getPinMode(pin) == INPUT && pinValue == 1 && Firmata.getPinState(pin) != 1) {
             // only handle INPUT here for backwards compatibility
 #if ARDUINO > 100
             pinMode(pin, INPUT_PULLUP);
@@ -385,7 +392,7 @@ void digitalWriteCallback(byte port, int value)
             pinWriteMask |= mask;
 #endif
           }
-          pinState[pin] = pinValue;
+          Firmata.setPinState(pin, pinValue);
         }
       }
       mask = mask << 1;
@@ -622,6 +629,9 @@ void sysexCallback(byte command, byte argc, byte *argv)
           Firmata.write(PIN_MODE_I2C);
           Firmata.write(1);  // TODO: could assign a number to map to SCL or SDA
         }
+#ifdef FIRMATA_SERIAL_FEATURE
+        serialFeature.handleCapability(pin);
+#endif
         Firmata.write(127);
       }
       Firmata.write(END_SYSEX);
@@ -633,10 +643,10 @@ void sysexCallback(byte command, byte argc, byte *argv)
         Firmata.write(PIN_STATE_RESPONSE);
         Firmata.write(pin);
         if (pin < TOTAL_PINS) {
-          Firmata.write((byte)pinConfig[pin]);
-          Firmata.write((byte)pinState[pin] & 0x7F);
-          if (pinState[pin] & 0xFF80) Firmata.write((byte)(pinState[pin] >> 7) & 0x7F);
-          if (pinState[pin] & 0xC000) Firmata.write((byte)(pinState[pin] >> 14) & 0x7F);
+          Firmata.write(Firmata.getPinMode(pin));
+          Firmata.write((byte)Firmata.getPinState(pin) & 0x7F);
+          if (Firmata.getPinState(pin) & 0xFF80) Firmata.write((byte)(Firmata.getPinState(pin) >> 7) & 0x7F);
+          if (Firmata.getPinState(pin) & 0xC000) Firmata.write((byte)(Firmata.getPinState(pin) >> 14) & 0x7F);
         }
         Firmata.write(END_SYSEX);
       }
@@ -648,6 +658,12 @@ void sysexCallback(byte command, byte argc, byte *argv)
         Firmata.write(IS_PIN_ANALOG(pin) ? PIN_TO_ANALOG(pin) : 127);
       }
       Firmata.write(END_SYSEX);
+      break;
+
+    case SERIAL_MESSAGE:
+#ifdef FIRMATA_SERIAL_FEATURE
+      serialFeature.handleSysex(command, argc, argv);
+#endif
       break;
   }
 }
@@ -683,6 +699,10 @@ void disableI2CPins() {
 void systemResetCallback()
 {
   isResetting = true;
+
+#ifdef FIRMATA_SERIAL_FEATURE
+  serialFeature.reset();
+#endif
 
   if (isI2CEnabled) {
     disableI2CPins();
@@ -772,7 +792,7 @@ void loop()
     previousMillis = currentMillis;
     /* ANALOGREAD - do all analogReads() at the configured sampling interval */
     for (pin = 0; pin < TOTAL_PINS; pin++) {
-      if (IS_PIN_ANALOG(pin) && pinConfig[pin] == PIN_MODE_ANALOG) {
+      if (IS_PIN_ANALOG(pin) && Firmata.getPinMode(pin) == PIN_MODE_ANALOG) {
         analogPin = PIN_TO_ANALOG(pin);
         if (analogInputsToReport & (1 << analogPin)) {
           Firmata.sendAnalog(analogPin, analogRead(analogPin));
@@ -786,4 +806,8 @@ void loop()
       }
     }
   }
+
+#ifdef FIRMATA_SERIAL_FEATURE
+  serialFeature.update();
+#endif
 }

--- a/examples/StandardFirmataBLE/StandardFirmataBLE.ino
+++ b/examples/StandardFirmataBLE/StandardFirmataBLE.ino
@@ -756,10 +756,27 @@ void setup()
 
   stream.setLocalName(FIRMATA_BLE_LOCAL_NAME);
 
+// setConnectionInterval is not available in the CurieBLE library included in the
+// Intel Curie Boards package v1.0.5 (latest version via the Boards Manager). Without
+// setConnectionInterval, the BLE reporting rate for analog input and I2C read continuous mode
+// will be very slow (150ms instead of 30ms).
+// However, you can manually update CurieBLE to get the functionality now. Follow these steps:
+// 1. Install Intel Curie Boards v1.0.5 via the Arduino Boards manager (use Arduino 1.6.7 or newer)
+// 2. Download or clone corelibs-arduino101: https://github.com/01org/corelibs-arduino101
+// 3. Make a copy of the CurieBLE directory found in corelibs-arduino101/libraries/
+// 4. Find the Arduino15 directory on your computer:
+//    OS X:    ~/Library/Arduino15
+//    Windows: C:\Users\(username)\AppData\Local\Arduino15
+//    Linux:   ~/.arduino15
+// 5. From the Arduino15 directory, navigate to: /packages/Intel/hardware/arc32/1.0.5/libraries/
+// 6. Replace the CurieBLE library with the version you copied in step 3
+// 7. Comment out the #ifndef statement below and the following #endif statement
+#ifndef _VARIANT_ARDUINO_101_X_
   // set the BLE connection interval - this is the fastest interval you can read inputs
   stream.setConnectionInterval(FIRMATA_BLE_MIN_INTERVAL, FIRMATA_BLE_MAX_INTERVAL);
   // set how often the BLE TX buffer is flushed (if not full)
   stream.setFlushInterval(FIRMATA_BLE_MAX_INTERVAL);
+#endif
 
 #ifdef BLE_REQ
   for (byte i = 0; i < TOTAL_PINS; i++) {

--- a/examples/StandardFirmataBLE/StandardFirmataBLE.ino
+++ b/examples/StandardFirmataBLE/StandardFirmataBLE.ino
@@ -20,7 +20,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated by Jeff Hoefs: March 5th, 2016
+  Last updated March 13th, 2016
 */
 
 #include <Servo.h>
@@ -85,7 +85,7 @@ struct i2c_device_info {
 /* for i2c read continuous more */
 i2c_device_info query[I2C_MAX_QUERIES];
 
-byte i2cRxData[32];
+byte i2cRxData[64];
 boolean isI2CEnabled = false;
 signed char queryIndex = -1;
 // default delay time between i2c read request and Wire.requestFrom()

--- a/examples/StandardFirmataBLE/StandardFirmataBLE.ino
+++ b/examples/StandardFirmataBLE/StandardFirmataBLE.ino
@@ -20,26 +20,25 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated by Jeff Hoefs: January 3rd, 2015
+  Last updated by Jeff Hoefs: February 20th, 2016
 */
 
 #include <Servo.h>
 #include <Wire.h>
 #include <Firmata.h>
 
-#include <CurieBle.h>
-#include "utility/BLEStream.h"
+#include "bleConfig.h"
 
 //#define SERIAL_DEBUG
 #include "utility/firmataDebug.h"
 
-#define I2C_WRITE                   B00000000
-#define I2C_READ                    B00001000
-#define I2C_READ_CONTINUOUSLY       B00010000
-#define I2C_STOP_READING            B00011000
-#define I2C_READ_WRITE_MODE_MASK    B00011000
-#define I2C_10BIT_ADDRESS_MODE_MASK B00100000
-#define I2C_END_TX_MASK             B01000000
+#define I2C_WRITE                   0x00 //B00000000
+#define I2C_READ                    0x08 //B00001000
+#define I2C_READ_CONTINUOUSLY       0x10 //B00010000
+#define I2C_STOP_READING            0x18 //B00011000
+#define I2C_READ_WRITE_MODE_MASK    0x18 //B00011000
+#define I2C_10BIT_ADDRESS_MODE_MASK 0x20 //B00100000
+#define I2C_END_TX_MASK             0x40 //B01000000
 #define I2C_STOP_TX                 1
 #define I2C_RESTART_TX              0
 #define I2C_MAX_QUERIES             8
@@ -94,8 +93,6 @@ byte detachedServoCount = 0;
 byte servoCount = 0;
 
 boolean isResetting = false;
-
-BLEStream stream(0);
 
 /* utility functions */
 void wireWrite(byte data)
@@ -735,6 +732,14 @@ void setup()
   Firmata.attach(SYSTEM_RESET, systemResetCallback);
 
   stream.setLocalName("FIRMATA");
+
+#ifdef BLE_REQ
+  for (byte i = 0; i < TOTAL_PINS; i++) {
+    if (IS_IGNORE_BLE_PINS(i)) {
+      Firmata.setPinMode(i, PIN_MODE_IGNORE);
+    }
+  }
+#endif
 
   stream.begin();
   Firmata.begin(stream);

--- a/examples/StandardFirmataBLE/bleConfig.h
+++ b/examples/StandardFirmataBLE/bleConfig.h
@@ -22,14 +22,13 @@
  * If you are using a RedBearLab BLE shield, uncomment the define below.
  * Also, change the define for BLE_RST if you have the jumper set to pin 7 rather than pin 4.
  *
- * You will need to use the shield with an Arduino Mega, Due or other board with sufficient
+ * You will need to use the shield with an Arduino Zero, Due, Mega, or other board with sufficient
  * Flash and RAM. Arduino Uno, Leonardo and other ATmega328p and Atmega32u4 boards to not have
  * enough memory to run StandardFirmataBLE.
  *
  * TODO: verify if this works and with which boards it works.
  *
  * Test script: https://gist.github.com/soundanalogous/927360b797574ed50e27
- * (may need to skip capabilities - see https://gist.github.com/soundanalogous/d39bb3eb36333a0906df)
  */
 //#define REDBEAR_BLE_SHIELD
 

--- a/examples/StandardFirmataBLE/bleConfig.h
+++ b/examples/StandardFirmataBLE/bleConfig.h
@@ -1,16 +1,20 @@
-/*===================================================================================
+/*==================================================================================================
  * BLE CONFIGURATION
  *
- * If you are using an Arduino 101, you do not need to make any changes to this
- * file. If you are using another supported BLE board or shield, follow the
- * instructions for the specific board or shield below.
+ * If you are using an Arduino 101, you do not need to make any changes to this file (unless you
+ * need a unique ble local name (see below). If you are using another supported BLE board or shield,
+ * follow the instructions for the specific board or shield below.
  *
  * Supported boards and shields:
  * - Arduino 101 (recommended)
  * - RedBearLab BLE Shield (v2)  ** to be verified **
  * - RedBearLab BLE Nano ** works with modifications **
  *
- *==================================================================================*/
+ *================================================================================================*/
+
+// change this to a unique name per board if running StandardFirmataBLE on multiple boards
+// within the same physical space
+#define FIRMATA_BLE_LOCAL_NAME "FIRMATA"
 
 /*
  * RedBearLab BLE Shield
@@ -42,9 +46,9 @@ BLEStream stream(BLE_REQ, BLE_RDY, BLE_RST);
 #endif
 
 
-/*===================================================================================
+/*==================================================================================================
  * END BLE CONFIGURATION - you should not need to change anything below this line
- *==================================================================================*/
+ *================================================================================================*/
 
 /*
  * Arduino 101
@@ -52,8 +56,7 @@ BLEStream stream(BLE_REQ, BLE_RDY, BLE_RST);
  * Test script: https://gist.github.com/soundanalogous/927360b797574ed50e27
  */
 #ifdef _VARIANT_ARDUINO_101_X_
-#include <CurieBle.h>
-//#include <CurieBLE.h> // switch to this once new Arduino 101 board package is available
+#include <CurieBLE.h>
 #include "utility/BLEStream.h"
 BLEStream stream;
 #endif

--- a/examples/StandardFirmataBLE/bleConfig.h
+++ b/examples/StandardFirmataBLE/bleConfig.h
@@ -8,6 +8,7 @@
  * Supported boards and shields:
  * - Arduino 101 (recommended)
  * - RedBearLab BLE Shield (v2)  ** to be verified **
+ * - RedBearLab BLE Nano ** works with modifications **
  *
  *==================================================================================*/
 
@@ -59,11 +60,17 @@ BLEStream stream;
 
 
 /*
- * RedBearLab BLE Nano
+ * RedBearLab BLE Nano (with default switch settings)
+ *
  * Blocked on this issue: https://github.com/RedBearLab/nRF51822-Arduino/issues/46
- * Also, need to skip Capability Query (see example in test script)
+ * Works with modifications. See comments at top of the test script referenced below.
+ * When the RBL nRF51822-Arduino library issue is resolved, this should work witout
+ * any modifications.
  *
  * Test script: https://gist.github.com/soundanalogous/d39bb3eb36333a0906df
+ *
+ * Note: If you have changed the solder jumpers on the Nano you may encounter issues since
+ * the pins are currently mapped in Firmata only for the default (factory) jumper settings.
  */
 // #ifdef BLE_NANO
 // #include <BLEPeripheral.h>
@@ -74,8 +81,10 @@ BLEStream stream;
 
 /*
  * RedBearLab Blend and Blend Micro
- * StandardFirmataBLE is requires too much Flash and RAM to run on Blend Micro
- * may work with ConfigurableFirmata selecting only analog and digital I/O
+ *
+ * StandardFirmataBLE requires too much Flash and RAM to run on the ATmega32u4-based Blend
+ * and Blend Micro boards. It may work with ConfigurableFirmata selecting only analog and/or
+ * digital I/O.
  */
 // #if defined(BLEND_MICRO) || defined(BLEND)
 // #include <SPI.h>

--- a/examples/StandardFirmataBLE/bleConfig.h
+++ b/examples/StandardFirmataBLE/bleConfig.h
@@ -1,0 +1,95 @@
+/*===================================================================================
+ * BLE CONFIGURATION
+ *
+ * If you are using an Arduino 101, you do not need to make any changes to this
+ * file. If you are using another supported BLE board or shield, follow the
+ * instructions for the specific board or shield below.
+ *
+ * Supported boards and shields:
+ * - Arduino 101 (recommended)
+ * - RedBearLab BLE Shield (v2)  ** to be verified **
+ *
+ *==================================================================================*/
+
+/*
+ * RedBearLab BLE Shield
+ *
+ * If you are using a RedBearLab BLE shield, uncomment the define below.
+ * Also, change the define for BLE_RST if you have the jumper set to pin 7 rather than pin 4.
+ *
+ * You will need to use the shield with an Arduino Mega, Due or other board with sufficient
+ * Flash and RAM. Arduino Uno, Leonardo and other ATmega328p and Atmega32u4 boards to not have
+ * enough memory to run StandardFirmataBLE.
+ *
+ * TODO: verify if this works and with which boards it works.
+ *
+ * Test script: https://gist.github.com/soundanalogous/927360b797574ed50e27
+ * (may need to skip capabilities - see https://gist.github.com/soundanalogous/d39bb3eb36333a0906df)
+ */
+//#define REDBEAR_BLE_SHIELD
+
+#ifdef REDBEAR_BLE_SHIELD
+#include <SPI.h>
+#include <BLEPeripheral.h>
+#include "utility/BLEStream.h"
+
+#define BLE_REQ  9
+#define BLE_RDY  8
+#define BLE_RST  4 // 4 or 7 via jumper on shield
+
+BLEStream stream(BLE_REQ, BLE_RDY, BLE_RST);
+#endif
+
+
+/*===================================================================================
+ * END BLE CONFIGURATION - you should not need to change anything below this line
+ *==================================================================================*/
+
+/*
+ * Arduino 101
+ *
+ * Test script: https://gist.github.com/soundanalogous/927360b797574ed50e27
+ */
+#ifdef _VARIANT_ARDUINO_101_X_
+#include <CurieBle.h>
+//#include <CurieBLE.h> // switch to this once new Arduino 101 board package is available
+#include "utility/BLEStream.h"
+BLEStream stream;
+#endif
+
+
+/*
+ * RedBearLab BLE Nano
+ * Blocked on this issue: https://github.com/RedBearLab/nRF51822-Arduino/issues/46
+ * Also, need to skip Capability Query (see example in test script)
+ *
+ * Test script: https://gist.github.com/soundanalogous/d39bb3eb36333a0906df
+ */
+// #ifdef BLE_NANO
+// #include <BLEPeripheral.h>
+// #include "utility/BLEStream.h"
+// BLEStream stream;
+// #endif
+
+
+/*
+ * RedBearLab Blend and Blend Micro
+ * StandardFirmataBLE is requires too much Flash and RAM to run on Blend Micro
+ * may work with ConfigurableFirmata selecting only analog and digital I/O
+ */
+// #if defined(BLEND_MICRO) || defined(BLEND)
+// #include <SPI.h>
+// #include <BLEPeripheral.h>
+// #include "utility/BLEStream.h"
+
+// #define BLE_REQ  6
+// #define BLE_RDY  7
+// #define BLE_RST  4
+
+// BLEStream stream(BLE_REQ, BLE_RDY, BLE_RST);
+// #endif
+
+
+#if defined(BLE_REQ) && defined(BLE_RDY) && defined(BLE_RST)
+#define IS_IGNORE_BLE_PINS(p) ((p) == BLE_REQ || (p) == BLE_RDY || (p) == BLE_RST)
+#endif

--- a/utility/BLEStream.cpp
+++ b/utility/BLEStream.cpp
@@ -1,0 +1,132 @@
+/*
+  BLEStream.cpp
+
+  Based on BLESerial.cpp by Voita Molda
+  https://github.com/vojtamolda/BLEPeripheral/blob/master/examples/uart/BLESerial.cpp
+ */
+
+#include "BLEStream.h"
+
+// #define BLE_SERIAL_DEBUG
+
+BLEStream* BLEStream::_instance = NULL;
+
+BLEStream::BLEStream(unsigned char) :
+  BLEPeripheral()
+{
+  this->_txCount = 0;
+  this->_rxHead = this->_rxTail = 0;
+  this->_flushed = 0;
+  BLEStream::_instance = this;
+
+  addAttribute(this->_uartService);
+  addAttribute(this->_uartNameDescriptor);
+  setAdvertisedServiceUuid(this->_uartService.uuid());
+  addAttribute(this->_rxCharacteristic);
+  addAttribute(this->_rxNameDescriptor);
+  this->_rxCharacteristic.setEventHandler(BLEWritten, BLEStream::_received);
+  addAttribute(this->_txCharacteristic);
+  addAttribute(this->_txNameDescriptor);
+}
+
+void BLEStream::begin(...) {
+  BLEPeripheral::begin();
+  #ifdef BLE_SERIAL_DEBUG
+    Serial.println(F("BLEStream::begin()"));
+  #endif
+}
+
+bool BLEStream::poll() {
+  this->_connected = BLEPeripheral::connected();
+  if (millis() > this->_flushed + 100) flush();
+  return this->_connected;
+}
+
+void BLEStream::end() {
+  this->_rxCharacteristic.setEventHandler(BLEWritten, NULL);
+  this->_rxHead = this->_rxTail = 0;
+  flush();
+  BLEPeripheral::disconnect();
+}
+
+int BLEStream::available(void) {
+  int retval = (this->_rxHead - this->_rxTail + sizeof(this->_rxBuffer)) % sizeof(this->_rxBuffer);
+  #ifdef BLE_SERIAL_DEBUG
+    Serial.print(F("BLEStream::available() = "));
+    Serial.println(retval);
+  #endif
+  return retval;
+}
+
+int BLEStream::peek(void) {
+  if (this->_rxTail == this->_rxHead) return -1;
+  unsigned char byte = this->_rxBuffer[this->_rxTail];
+  #ifdef BLE_SERIAL_DEBUG
+    Serial.print(F("BLEStream::peek() = "));
+    Serial.print((char) byte);
+    Serial.print(F(" 0x"));
+    Serial.println(byte, HEX);
+  #endif
+  return byte;
+}
+
+int BLEStream::read(void) {
+  if (this->_rxTail == this->_rxHead) return -1;
+  this->_rxTail = (this->_rxTail + 1) % sizeof(this->_rxBuffer);
+  unsigned char byte = this->_rxBuffer[this->_rxTail];
+  #ifdef BLE_SERIAL_DEBUG
+    Serial.print(F("BLEStream::read() = "));
+    Serial.print((char) byte);
+    Serial.print(F(" 0x"));
+    Serial.println(byte, HEX);
+  #endif
+  return byte;
+}
+
+void BLEStream::flush(void) {
+  if (this->_txCount == 0) return;
+  if (this->_connected) this->_txCharacteristic.setValue(this->_txBuffer, this->_txCount);
+  this->_flushed = millis();
+  this->_txCount = 0;
+  #ifdef BLE_SERIAL_DEBUG
+    Serial.println(F("BLEStream::flush()"));
+  #endif
+}
+
+size_t BLEStream::write(uint8_t byte) {
+  this->_txBuffer[this->_txCount++] = byte;
+  if (this->_txCount == sizeof(this->_txBuffer)) flush();
+  #ifdef BLE_SERIAL_DEBUG
+    Serial.print(F("BLEStream::write("));
+    Serial.print((char) byte);
+    Serial.print(F(" 0x"));
+    Serial.print(byte, HEX);
+    Serial.println(F(") = 1"));
+  #endif
+  return 1;
+}
+
+BLEStream::operator bool() {
+  bool retval = this->_connected = BLEPeripheral::connected();
+  #ifdef BLE_SERIAL_DEBUG
+    Serial.print(F("BLEStream::operator bool() = "));
+    Serial.println(retval);
+  #endif
+  return retval;
+}
+
+void BLEStream::_received(const unsigned char* data, size_t size) {
+  for (int i = 0; i < size; i++) {
+    this->_rxHead = (this->_rxHead + 1) % sizeof(this->_rxBuffer);
+    this->_rxBuffer[this->_rxHead] = data[i];
+  }
+  #ifdef BLE_SERIAL_DEBUG
+    Serial.print(F("BLEStream::received("));
+    for (int i = 0; i < size; i++) Serial.print((char)data[i]);
+    Serial.println(F(")"));
+  #endif
+}
+
+void BLEStream::_received(BLECentral& /*central*/, BLECharacteristic& rxCharacteristic) {
+  BLEStream::_instance->_received(rxCharacteristic.value(), rxCharacteristic.valueLength());
+}

--- a/utility/BLEStream.cpp
+++ b/utility/BLEStream.cpp
@@ -21,6 +21,7 @@ BLEStream::BLEStream(unsigned char req, unsigned char rdy, unsigned char rst) :
   this->_txCount = 0;
   this->_rxHead = this->_rxTail = 0;
   this->_flushed = 0;
+  this->_packetTxCount = 0;
   BLEStream::_instance = this;
 
   addAttribute(this->_uartService);
@@ -109,6 +110,24 @@ int BLEStream::read(void)
 void BLEStream::flush(void)
 {
   if (this->_txCount == 0) return;
+#ifndef _VARIANT_ARDUINO_101_X_
+  long diff = millis() - this->_flushed;
+  // flush() is called approximately every 1ms or less when sending multiple packets and
+  // otherwise no more frequently than BLESTREAM_TXBUFFER_FLUSH_INTERVAL
+  // TODO - determine if 2 is the best value or if something higher is necessary
+  if (diff < 2) {
+    // 2 is the max number of packets that can be sent in short succession
+    // TODO - get the max packet value programatically
+    if (++this->_packetTxCount >= 2) {
+      // delay after 2 packets have been sent in short succession
+      // 100ms is the minimum necessary delay value
+      delay(100);
+      this->_packetTxCount = 0;
+    }
+  } else {
+    this->_packetTxCount = 0;
+  }
+#endif
   this->_txCharacteristic.setValue(this->_txBuffer, this->_txCount);
   this->_flushed = millis();
   this->_txCount = 0;

--- a/utility/BLEStream.cpp
+++ b/utility/BLEStream.cpp
@@ -2,17 +2,21 @@
   BLEStream.cpp
 
   Based on BLESerial.cpp by Voita Molda
-  https://github.com/vojtamolda/BLEPeripheral/blob/master/examples/uart/BLESerial.cpp
+  https://github.com/sandeepmistry/arduino-BLEPeripheral/blob/master/examples/serial/BLESerial.cpp
  */
 
 #include "BLEStream.h"
 
-//#define BLE_SERIAL_DEBUG
+// #define BLE_SERIAL_DEBUG
 
 BLEStream* BLEStream::_instance = NULL;
 
-BLEStream::BLEStream(unsigned char) :
+BLEStream::BLEStream(unsigned char req, unsigned char rdy, unsigned char rst) :
+#if defined(_VARIANT_ARDUINO_101_X_)
   BLEPeripheral()
+#else
+  BLEPeripheral(req, rdy, rst)
+#endif
 {
   this->_txCount = 0;
   this->_rxHead = this->_rxTail = 0;
@@ -29,100 +33,130 @@ BLEStream::BLEStream(unsigned char) :
   addAttribute(this->_txNameDescriptor);
 }
 
-void BLEStream::begin(...) {
+void BLEStream::begin(...)
+{
   BLEPeripheral::begin();
-  #ifdef BLE_SERIAL_DEBUG
-    Serial.println(F("BLEStream::begin()"));
-  #endif
+#ifdef BLE_SERIAL_DEBUG
+  Serial.println(F("BLEStream::begin()"));
+#endif
 }
 
-bool BLEStream::poll() {
+bool BLEStream::poll()
+{
+  // BLEPeripheral::poll is called each time connected() is called
   this->_connected = BLEPeripheral::connected();
-  if (millis() > this->_flushed + BLESTREAM_TXBUFFER_FLUSH_INTERVAL) flush();
+  if (millis() > this->_flushed + BLESTREAM_TXBUFFER_FLUSH_INTERVAL) {
+    flush();
+  }
   return this->_connected;
 }
 
-void BLEStream::end() {
+void BLEStream::end()
+{
   this->_rxCharacteristic.setEventHandler(BLEWritten, NULL);
   this->_rxHead = this->_rxTail = 0;
   flush();
   BLEPeripheral::disconnect();
 }
 
-int BLEStream::available(void) {
+int BLEStream::available(void)
+{
+// BLEPeripheral::poll only calls delay(1) in CurieBLE so skipping it here to avoid the delay
+#ifndef _VARIANT_ARDUINO_101_X_
+  // TODO Need to do more testing to determine if all of these calls to BLEPeripheral::poll are
+  // actually necessary. Seems to run fine without them, but only minimal testing so far.
+  BLEPeripheral::poll();
+#endif
   int retval = (this->_rxHead - this->_rxTail + sizeof(this->_rxBuffer)) % sizeof(this->_rxBuffer);
-  #ifdef BLE_SERIAL_DEBUG
-    if (retval > 0) {
-      Serial.print(F("BLEStream::available() = "));
-      Serial.println(retval);
-    }
-  #endif
+#ifdef BLE_SERIAL_DEBUG
+  if (retval > 0) {
+    Serial.print(F("BLEStream::available() = "));
+    Serial.println(retval);
+  }
+#endif
   return retval;
 }
 
-int BLEStream::peek(void) {
+int BLEStream::peek(void)
+{
+#ifndef _VARIANT_ARDUINO_101_X_
+  BLEPeripheral::poll();
+#endif
   if (this->_rxTail == this->_rxHead) return -1;
-  unsigned char byte = this->_rxBuffer[this->_rxTail];
-  #ifdef BLE_SERIAL_DEBUG
-    Serial.print(F("BLEStream::peek() = 0x"));
-    Serial.println(byte, HEX);
-  #endif
+  uint8_t byte = this->_rxBuffer[this->_rxTail];
+#ifdef BLE_SERIAL_DEBUG
+  Serial.print(F("BLEStream::peek() = 0x"));
+  Serial.println(byte, HEX);
+#endif
   return byte;
 }
 
-int BLEStream::read(void) {
+int BLEStream::read(void)
+{
+#ifndef _VARIANT_ARDUINO_101_X_
+  BLEPeripheral::poll();
+#endif
   if (this->_rxTail == this->_rxHead) return -1;
   this->_rxTail = (this->_rxTail + 1) % sizeof(this->_rxBuffer);
-  unsigned char byte = this->_rxBuffer[this->_rxTail];
-  #ifdef BLE_SERIAL_DEBUG
-    Serial.print(F("BLEStream::read() = 0x"));
-    Serial.println(byte, HEX);
-  #endif
+  uint8_t byte = this->_rxBuffer[this->_rxTail];
+#ifdef BLE_SERIAL_DEBUG
+  Serial.print(F("BLEStream::read() = 0x"));
+  Serial.println(byte, HEX);
+#endif
   return byte;
 }
 
-void BLEStream::flush(void) {
+void BLEStream::flush(void)
+{
   if (this->_txCount == 0) return;
-  if (this->_connected) this->_txCharacteristic.setValue(this->_txBuffer, this->_txCount);
+  this->_txCharacteristic.setValue(this->_txBuffer, this->_txCount);
   this->_flushed = millis();
   this->_txCount = 0;
-  #ifdef BLE_SERIAL_DEBUG
-    Serial.println(F("BLEStream::flush()"));
-  #endif
+#ifdef BLE_SERIAL_DEBUG
+  Serial.println(F("BLEStream::flush()"));
+#endif
 }
 
-size_t BLEStream::write(uint8_t byte) {
+size_t BLEStream::write(uint8_t byte)
+{
+#ifndef _VARIANT_ARDUINO_101_X_
+  BLEPeripheral::poll();
+#endif
+  if (this->_txCharacteristic.subscribed() == false) return 0;
   this->_txBuffer[this->_txCount++] = byte;
   if (this->_txCount == sizeof(this->_txBuffer)) flush();
-  #ifdef BLE_SERIAL_DEBUG
-    Serial.print(F("BLEStream::write( 0x"));
-    Serial.print(byte, HEX);
-    Serial.println(F(") = 1"));
-  #endif
+#ifdef BLE_SERIAL_DEBUG
+  Serial.print(F("BLEStream::write( 0x"));
+  Serial.print(byte, HEX);
+  Serial.println(F(") = 1"));
+#endif
   return 1;
 }
 
-BLEStream::operator bool() {
+BLEStream::operator bool()
+{
   bool retval = this->_connected = BLEPeripheral::connected();
-  #ifdef BLE_SERIAL_DEBUG
-    Serial.print(F("BLEStream::operator bool() = "));
-    Serial.println(retval);
-  #endif
+#ifdef BLE_SERIAL_DEBUG
+  Serial.print(F("BLEStream::operator bool() = "));
+  Serial.println(retval);
+#endif
   return retval;
 }
 
-void BLEStream::_received(const unsigned char* data, size_t size) {
-  for (int i = 0; i < size; i++) {
+void BLEStream::_received(const unsigned char* data, size_t size)
+{
+  for (size_t i = 0; i < size; i++) {
     this->_rxHead = (this->_rxHead + 1) % sizeof(this->_rxBuffer);
     this->_rxBuffer[this->_rxHead] = data[i];
   }
-  #ifdef BLE_SERIAL_DEBUG
-    Serial.print(F("BLEStream::received("));
-    for (int i = 0; i < size; i++) Serial.print(data[i], HEX);
-    Serial.println(F(")"));
-  #endif
+#ifdef BLE_SERIAL_DEBUG
+  Serial.print(F("BLEStream::received("));
+  for (int i = 0; i < size; i++) Serial.print(data[i], HEX);
+  Serial.println(F(")"));
+#endif
 }
 
-void BLEStream::_received(BLECentral& /*central*/, BLECharacteristic& rxCharacteristic) {
+void BLEStream::_received(BLECentral& /*central*/, BLECharacteristic& rxCharacteristic)
+{
   BLEStream::_instance->_received(rxCharacteristic.value(), rxCharacteristic.valueLength());
 }

--- a/utility/BLEStream.cpp
+++ b/utility/BLEStream.cpp
@@ -4,7 +4,7 @@
   Based on BLESerial.cpp by Voita Molda
   https://github.com/sandeepmistry/arduino-BLEPeripheral/blob/master/examples/serial/BLESerial.cpp
 
-  Last updated by Jeff Hoefs: March 5th, 2016
+  Last updated March 5th, 2016
  */
 
 #include "BLEStream.h"

--- a/utility/BLEStream.cpp
+++ b/utility/BLEStream.cpp
@@ -4,7 +4,7 @@
   Based on BLESerial.cpp by Voita Molda
   https://github.com/sandeepmistry/arduino-BLEPeripheral/blob/master/examples/serial/BLESerial.cpp
 
-  Last updated by Jeff Hoefs: February 28th, 2016
+  Last updated by Jeff Hoefs: March 5th, 2016
  */
 
 #include "BLEStream.h"
@@ -23,6 +23,7 @@ BLEStream::BLEStream(unsigned char req, unsigned char rdy, unsigned char rst) :
   this->_txCount = 0;
   this->_rxHead = this->_rxTail = 0;
   this->_flushed = 0;
+  this->_flushInterval = BLESTREAM_TXBUFFER_FLUSH_INTERVAL;
   BLEStream::_instance = this;
 
   addAttribute(this->_uartService);
@@ -47,7 +48,7 @@ bool BLEStream::poll()
 {
   // BLEPeripheral::poll is called each time connected() is called
   this->_connected = BLEPeripheral::connected();
-  if (millis() > this->_flushed + BLESTREAM_TXBUFFER_FLUSH_INTERVAL) {
+  if (millis() > this->_flushed + this->_flushInterval) {
     flush();
   }
   return this->_connected;
@@ -149,6 +150,13 @@ BLEStream::operator bool()
   Serial.println(retval);
 #endif
   return retval;
+}
+
+void BLEStream::setFlushInterval(int interval)
+{
+  if (interval > BLESTREAM_MIN_FLUSH_INTERVAL) {
+    this->_flushInterval = interval;
+  }
 }
 
 void BLEStream::_received(const unsigned char* data, size_t size)

--- a/utility/BLEStream.h
+++ b/utility/BLEStream.h
@@ -1,0 +1,54 @@
+/*
+  BLEStream.h
+
+  Based on BLESerial.cpp by Voita Molda
+  https://github.com/vojtamolda/BLEPeripheral/blob/master/examples/uart/BLESerial.h
+ */
+
+#ifndef _BLE_STREAM_H_
+#define _BLE_STREAM_H_
+
+#include <Arduino.h>
+#include <CurieBle.h>
+
+class BLEStream : public BLEPeripheral, public Stream
+{
+  public:
+    BLEStream(unsigned char);
+
+    void begin(...);
+    bool poll();
+    void end();
+
+    virtual int available(void);
+    virtual int peek(void);
+    virtual int read(void);
+    virtual void flush(void);
+    virtual size_t write(uint8_t byte);
+    using Print::write;
+    virtual operator bool();
+
+  private:
+    bool _connected;
+    unsigned long _flushed;
+    static BLEStream* _instance;
+
+    size_t _rxHead;
+    size_t _rxTail;
+    size_t _rxCount() const;
+    unsigned char _rxBuffer[256];
+    size_t _txCount;
+    unsigned char _txBuffer[BLE_MAX_ATTR_DATA_LEN];
+
+    BLEService _uartService = BLEService("6E400001-B5A3-F393-E0A9-E50E24DCCA9E");
+    BLEDescriptor _uartNameDescriptor = BLEDescriptor("2901", "UART");
+    BLECharacteristic _rxCharacteristic = BLECharacteristic("6E400002-B5A3-F393-E0A9-E50E24DCCA9E", BLEWriteWithoutResponse, BLE_MAX_ATTR_DATA_LEN);
+    BLEDescriptor _rxNameDescriptor = BLEDescriptor("2901", "RX - Receive Data (Write)");
+    BLECharacteristic _txCharacteristic = BLECharacteristic("6E400003-B5A3-F393-E0A9-E50E24DCCA9E", BLENotify, BLE_MAX_ATTR_DATA_LEN);
+    BLEDescriptor _txNameDescriptor = BLEDescriptor("2901", "TX - Transfer Data (Notify)");
+
+    void _received(const unsigned char* data, size_t size);
+    static void _received(BLECentral& /*central*/, BLECharacteristic& rxCharacteristic);
+};
+
+#endif

--- a/utility/BLEStream.h
+++ b/utility/BLEStream.h
@@ -11,6 +11,8 @@
 #include <Arduino.h>
 #include <CurieBle.h>
 
+#define BLESTREAM_TXBUFFER_FLUSH_INTERVAL 30
+
 class BLEStream : public BLEPeripheral, public Stream
 {
   public:

--- a/utility/BLEStream.h
+++ b/utility/BLEStream.h
@@ -3,6 +3,8 @@
 
   Based on BLESerial.cpp by Voita Molda
   https://github.com/sandeepmistry/arduino-BLEPeripheral/blob/master/examples/serial/BLESerial.h
+
+  Last updated by Jeff Hoefs: February 28th, 2016
  */
 
 #ifndef _BLE_STREAM_H_
@@ -52,8 +54,6 @@ class BLEStream : public BLEPeripheral, public Stream
     unsigned char _rxBuffer[256];
     size_t _txCount;
     unsigned char _txBuffer[_MAX_ATTR_DATA_LEN_];
-
-    uint8_t _packetTxCount;
 
     BLEService _uartService = BLEService("6E400001-B5A3-F393-E0A9-E50E24DCCA9E");
     BLEDescriptor _uartNameDescriptor = BLEDescriptor("2901", "UART");

--- a/utility/BLEStream.h
+++ b/utility/BLEStream.h
@@ -4,7 +4,7 @@
   Based on BLESerial.cpp by Voita Molda
   https://github.com/sandeepmistry/arduino-BLEPeripheral/blob/master/examples/serial/BLESerial.h
 
-  Last updated by Jeff Hoefs: March 5th, 2016
+  Last updated March 13th, 2016
  */
 
 #ifndef _BLE_STREAM_H_
@@ -19,11 +19,7 @@
 #define _MAX_ATTR_DATA_LEN_ BLE_ATTRIBUTE_MAX_VALUE_LENGTH
 #endif
 
-#if defined(_VARIANT_ARDUINO_101_X_)
-#define BLESTREAM_TXBUFFER_FLUSH_INTERVAL 30
-#else
 #define BLESTREAM_TXBUFFER_FLUSH_INTERVAL 80
-#endif
 #define BLESTREAM_MIN_FLUSH_INTERVAL 8 // minimum interval for flushing the TX buffer
 
 class BLEStream : public BLEPeripheral, public Stream

--- a/utility/BLEStream.h
+++ b/utility/BLEStream.h
@@ -2,21 +2,32 @@
   BLEStream.h
 
   Based on BLESerial.cpp by Voita Molda
-  https://github.com/vojtamolda/BLEPeripheral/blob/master/examples/uart/BLESerial.h
+  https://github.com/sandeepmistry/arduino-BLEPeripheral/blob/master/examples/serial/BLESerial.h
  */
 
 #ifndef _BLE_STREAM_H_
 #define _BLE_STREAM_H_
 
 #include <Arduino.h>
+#if defined(_VARIANT_ARDUINO_101_X_)
 #include <CurieBle.h>
+//#include <CurieBLE.h> // switch to this once new Arduino 101 board package is available
+#define _MAX_ATTR_DATA_LEN_ BLE_MAX_ATTR_DATA_LEN
+#else
+#include <BLEPeripheral.h>
+#define _MAX_ATTR_DATA_LEN_ BLE_ATTRIBUTE_MAX_VALUE_LENGTH
+#endif
 
+#if defined(_VARIANT_ARDUINO_101_X_)
 #define BLESTREAM_TXBUFFER_FLUSH_INTERVAL 30
+#else
+#define BLESTREAM_TXBUFFER_FLUSH_INTERVAL 50
+#endif
 
 class BLEStream : public BLEPeripheral, public Stream
 {
   public:
-    BLEStream(unsigned char);
+    BLEStream(unsigned char req = 0, unsigned char rdy = 0, unsigned char rst = 0);
 
     void begin(...);
     bool poll();
@@ -40,13 +51,13 @@ class BLEStream : public BLEPeripheral, public Stream
     size_t _rxCount() const;
     unsigned char _rxBuffer[256];
     size_t _txCount;
-    unsigned char _txBuffer[BLE_MAX_ATTR_DATA_LEN];
+    unsigned char _txBuffer[_MAX_ATTR_DATA_LEN_];
 
     BLEService _uartService = BLEService("6E400001-B5A3-F393-E0A9-E50E24DCCA9E");
     BLEDescriptor _uartNameDescriptor = BLEDescriptor("2901", "UART");
-    BLECharacteristic _rxCharacteristic = BLECharacteristic("6E400002-B5A3-F393-E0A9-E50E24DCCA9E", BLEWriteWithoutResponse, BLE_MAX_ATTR_DATA_LEN);
+    BLECharacteristic _rxCharacteristic = BLECharacteristic("6E400002-B5A3-F393-E0A9-E50E24DCCA9E", BLEWriteWithoutResponse, _MAX_ATTR_DATA_LEN_);
     BLEDescriptor _rxNameDescriptor = BLEDescriptor("2901", "RX - Receive Data (Write)");
-    BLECharacteristic _txCharacteristic = BLECharacteristic("6E400003-B5A3-F393-E0A9-E50E24DCCA9E", BLENotify, BLE_MAX_ATTR_DATA_LEN);
+    BLECharacteristic _txCharacteristic = BLECharacteristic("6E400003-B5A3-F393-E0A9-E50E24DCCA9E", BLENotify, _MAX_ATTR_DATA_LEN_);
     BLEDescriptor _txNameDescriptor = BLEDescriptor("2901", "TX - Transfer Data (Notify)");
 
     void _received(const unsigned char* data, size_t size);

--- a/utility/BLEStream.h
+++ b/utility/BLEStream.h
@@ -4,7 +4,7 @@
   Based on BLESerial.cpp by Voita Molda
   https://github.com/sandeepmistry/arduino-BLEPeripheral/blob/master/examples/serial/BLESerial.h
 
-  Last updated by Jeff Hoefs: February 28th, 2016
+  Last updated by Jeff Hoefs: March 5th, 2016
  */
 
 #ifndef _BLE_STREAM_H_
@@ -12,8 +12,7 @@
 
 #include <Arduino.h>
 #if defined(_VARIANT_ARDUINO_101_X_)
-#include <CurieBle.h>
-//#include <CurieBLE.h> // switch to this once new Arduino 101 board package is available
+#include <CurieBLE.h>
 #define _MAX_ATTR_DATA_LEN_ BLE_MAX_ATTR_DATA_LEN
 #else
 #include <BLEPeripheral.h>
@@ -25,6 +24,7 @@
 #else
 #define BLESTREAM_TXBUFFER_FLUSH_INTERVAL 80
 #endif
+#define BLESTREAM_MIN_FLUSH_INTERVAL 8 // minimum interval for flushing the TX buffer
 
 class BLEStream : public BLEPeripheral, public Stream
 {
@@ -34,6 +34,7 @@ class BLEStream : public BLEPeripheral, public Stream
     void begin(...);
     bool poll();
     void end();
+    void setFlushInterval(int);
 
     virtual int available(void);
     virtual int peek(void);
@@ -46,6 +47,7 @@ class BLEStream : public BLEPeripheral, public Stream
   private:
     bool _connected;
     unsigned long _flushed;
+    int _flushInterval;
     static BLEStream* _instance;
 
     size_t _rxHead;

--- a/utility/BLEStream.h
+++ b/utility/BLEStream.h
@@ -21,7 +21,7 @@
 #if defined(_VARIANT_ARDUINO_101_X_)
 #define BLESTREAM_TXBUFFER_FLUSH_INTERVAL 30
 #else
-#define BLESTREAM_TXBUFFER_FLUSH_INTERVAL 50
+#define BLESTREAM_TXBUFFER_FLUSH_INTERVAL 80
 #endif
 
 class BLEStream : public BLEPeripheral, public Stream
@@ -52,6 +52,8 @@ class BLEStream : public BLEPeripheral, public Stream
     unsigned char _rxBuffer[256];
     size_t _txCount;
     unsigned char _txBuffer[_MAX_ATTR_DATA_LEN_];
+
+    uint8_t _packetTxCount;
 
     BLEService _uartService = BLEService("6E400001-B5A3-F393-E0A9-E50E24DCCA9E");
     BLEDescriptor _uartNameDescriptor = BLEDescriptor("2901", "UART");


### PR DESCRIPTION
Adds StandardFirmataBLE for Arduino 101. Should also work with the RedBearLab BLE Shield (v2) when paired with a board with sufficient memory (Zero, Due, Mega). Works with RedBearLab BLE Nano with modifications ([detailed here](https://gist.github.com/soundanalogous/d39bb3eb36333a0906df)).

To use with the Arduino 101, you must install the Intel Curie Boards v1.0.5 package via the Arduino Boards Manager. Reporting of analog input values and I2C read (when using READ_CONTINUOUS mode) will be slow (~150ms interval). You can greatly speed things up however by manually patching the CurieBLE library via the [instructions here in StandardFirmataBLE.ino](https://github.com/firmata/arduino/blob/ble/examples/StandardFirmataBLE/StandardFirmataBLE.ino#L759-L773).

An example firmata.js (node.js) script for the Arduino 101 and RBL BLE shield is available here: https://gist.github.com/soundanalogous/927360b797574ed50e27

To use StandardFirmataBLE with supported RedBearLab boards, install the latest version of the [arduino-BLEPeripheral library](https://github.com/sandeepmistry/arduino-BLEPeripheral).
