### PR TITLE
WiFiClientStream added

### DIFF
--- a/examples/StandardFirmataWiFi/StandardFirmataWiFi.ino
+++ b/examples/StandardFirmataWiFi/StandardFirmataWiFi.ino
@@ -918,6 +918,7 @@ void setup()
    */
   while (!streamConnected && ++connectionAttempts <= MAX_CONN_ATTEMPTS) {
     delay(500);
+    DEBUG_PRINT(".");
     streamConnected = stream.maintain();
   }
   if (streamConnected) {  

--- a/examples/StandardFirmataWiFi/StandardFirmataWiFi.ino
+++ b/examples/StandardFirmataWiFi/StandardFirmataWiFi.ino
@@ -110,7 +110,7 @@
 // the minimum interval for sampling analog input
 #define MINIMUM_SAMPLING_INTERVAL   1
 
-#define WIFI_MAX_CONN_ATTEMPTS      3
+#define MAX_CONN_ATTEMPTS           20  // [500 ms] -> 10 s
 
 /*==============================================================================
  * GLOBAL VARIABLES
@@ -130,8 +130,8 @@ IPAddress subnet(SUBNET_MASK);
 IPAddress gateway(GATEWAY_IP_ADDRESS);
 #endif
 
-int wifiConnectionAttemptCounter = 0;
-int wifiStatus = WL_IDLE_STATUS;
+int connectionAttempts = 0;
+bool streamConnected = false;
 
 /* analog inputs */
 int analogInputsToReport = 0;      // bitwise array to store pin reporting
@@ -307,6 +307,12 @@ void checkDigitalInputs(void)
   if (TOTAL_PORTS > 14 && reportPINs[14]) outputPort(14, readPort(14, portConfigInputs[14]), false);
   if (TOTAL_PORTS > 15 && reportPINs[15]) outputPort(15, readPort(15, portConfigInputs[15]), false);
 }
+
+// -----------------------------------------------------------------------------
+// function forward declarations
+void enableI2CPins();
+void disableI2CPins();
+void reportAnalogCallback(byte analogPin, int value);
 
 // -----------------------------------------------------------------------------
 /* sets the pin mode to the correct state and sets the relevant bits in the
@@ -826,38 +832,26 @@ void systemResetCallback()
 }
 
 void printWifiStatus() {
-#if defined(ARDUINO_WIFI_SHIELD) || defined(WIFI_101) || defined(ESP8266_WIFI)
   if ( WiFi.status() != WL_CONNECTED )
   {
     DEBUG_PRINT( "WiFi connection failed. Status value: " );
     DEBUG_PRINTLN( WiFi.status() );
   }
   else
-#endif    //defined(ARDUINO_WIFI_SHIELD) || defined(WIFI_101) || defined(ESP8266_WIFI)
   {
     // print the SSID of the network you're attached to:
     DEBUG_PRINT( "SSID: " );
-
-#if defined(ARDUINO_WIFI_SHIELD) || defined(WIFI_101) || defined(ESP8266_WIFI)
     DEBUG_PRINTLN( WiFi.SSID() );
-#endif    //defined(ARDUINO_WIFI_SHIELD) || defined(WIFI_101) || defined(ESP8266_WIFI)
 
     // print your WiFi shield's IP address:
     DEBUG_PRINT( "IP Address: " );
-
-#if defined(ARDUINO_WIFI_SHIELD) || defined(WIFI_101) || defined(ESP8266_WIFI)
     IPAddress ip = WiFi.localIP();
     DEBUG_PRINTLN( ip );
-#endif    //defined(ARDUINO_WIFI_SHIELD) || defined(WIFI_101) || defined(ESP8266_WIFI)
 
     // print the received signal strength:
     DEBUG_PRINT( "signal strength (RSSI): " );
-
-#if defined(ARDUINO_WIFI_SHIELD) || defined(WIFI_101) || defined(ESP8266_WIFI)
     long rssi = WiFi.RSSI();
     DEBUG_PRINT( rssi );
-#endif    //defined(ARDUINO_WIFI_SHIELD) || defined(WIFI_101) || defined(ESP8266_WIFI)
-
     DEBUG_PRINTLN( " dBm" );
   }
 }
@@ -890,7 +884,7 @@ void setup()
 #ifdef STATIC_IP_ADDRESS
   DEBUG_PRINT( "Using static IP: " );
   DEBUG_PRINTLN( local_ip );
-#ifdef ESP8266_WIFI
+#if defined(ESP8266_WIFI) || (defined(SUBNET_MASK) && defined(GATEWAY_IP_ADDRESS))
   stream.config( local_ip , gateway, subnet );
 #else
   // you can also provide a static IP in the begin() functions, but this simplifies
@@ -902,37 +896,35 @@ void setup()
 #endif
 
   /*
-   * Configure WiFi security
+   * Configure WiFi security and initiate WiFi connection
    */
 #if defined(WIFI_WEP_SECURITY)
-  while (wifiStatus != WL_CONNECTED) {
     DEBUG_PRINT( "Attempting to connect to WEP SSID: " );
     DEBUG_PRINTLN(ssid);
-    wifiStatus = stream.begin( ssid, wep_index, wep_key, SERVER_PORT );
-    delay(5000); // TODO - determine minimum delay
-    if (++wifiConnectionAttemptCounter > WIFI_MAX_CONN_ATTEMPTS) break;
-  }
-
+  stream.begin(ssid, wep_index, wep_key);
 #elif defined(WIFI_WPA_SECURITY)
-  while (wifiStatus != WL_CONNECTED) {
     DEBUG_PRINT( "Attempting to connect to WPA SSID: " );
     DEBUG_PRINTLN(ssid);
-    wifiStatus = stream.begin(ssid, wpa_passphrase, SERVER_PORT);
-    delay(5000); // TODO - determine minimum delay
-    if (++wifiConnectionAttemptCounter > WIFI_MAX_CONN_ATTEMPTS) break;
-  }
-
+  stream.begin(ssid, wpa_passphrase);
 #else                          //OPEN network
-  while (wifiStatus != WL_CONNECTED) {
     DEBUG_PRINTLN( "Attempting to connect to open SSID: " );
     DEBUG_PRINTLN(ssid);
-    wifiStatus = stream.begin(ssid, SERVER_PORT);
-    delay(5000); // TODO - determine minimum delay
-    if (++wifiConnectionAttemptCounter > WIFI_MAX_CONN_ATTEMPTS) break;
-  }
+  stream.begin(ssid);
 #endif //defined(WIFI_WEP_SECURITY)
-
   DEBUG_PRINTLN( "WiFi setup done" );
+
+  /*
+   * Wait for TCP connection to be established
+   */
+  while (!streamConnected && ++connectionAttempts <= MAX_CONN_ATTEMPTS) {
+    delay(500);
+    streamConnected = stream.maintain();
+  }
+  if (streamConnected) {  
+    DEBUG_PRINTLN( "TCP connection established" );
+  } else {
+    DEBUG_PRINTLN( "failed to establish TCP connection" );    
+  }
   printWifiStatus();
 
   /*

--- a/examples/StandardFirmataWiFi/wifiConfig.h
+++ b/examples/StandardFirmataWiFi/wifiConfig.h
@@ -30,16 +30,16 @@
  */
 //#define WIFI_101
 
-//do not modify the following 10 lines
+//do not modify the following 11 lines
 #if defined(ARDUINO_SAMD_MKR1000) && !defined(WIFI_101)
 // automatically include if compiling for MRK1000
 #define WIFI_101
 #endif
 #ifdef WIFI_101
 #include <WiFi101.h>
-#include "utility/WiFiStream.h"
-WiFiStream stream;
-#define WIFI_LIB_INCLUDED
+#include "utility/WiFiClientStream.h"
+#include "utility/WiFiServerStream.h"
+  #define WIFI_LIB_INCLUDED
 #endif
 
 /*
@@ -57,8 +57,8 @@ WiFiStream stream;
 //do not modify the following 10 lines
 #ifdef ARDUINO_WIFI_SHIELD
 #include <WiFi.h>
-#include "utility/WiFiStream.h"
-WiFiStream stream;
+#include "utility/WiFiClientStream.h"
+#include "utility/WiFiServerStream.h"
   #ifdef WIFI_LIB_INCLUDED
   #define MULTIPLE_WIFI_LIB_INCLUDES
   #else
@@ -85,8 +85,8 @@ WiFiStream stream;
 #endif
 #ifdef ESP8266_WIFI
 #include <ESP8266WiFi.h>
-#include "utility/WiFiStream.h"
-WiFiStream stream;
+#include "utility/WiFiClientStream.h"
+#include "utility/WiFiServerStream.h"
   #ifdef WIFI_LIB_INCLUDED
   #define MULTIPLE_WIFI_LIB_INCLUDES
   #else
@@ -122,12 +122,17 @@ char ssid[] = "your_network_name";
 //#define GATEWAY_IP_ADDRESS 0,0,0,0       // REQUIRED for ESP8266_WIFI, optional for others
 
 
-// STEP 4 [REQUIRED for all boards and shields]
+// STEP 4 [OPTIONAL for all boards and shields]
+// uncomment and replace with the IP address of your server if the Arduino is the TCP client
+//#define SERVER_IP 10, 0, 0, 15
+
+
+// STEP 5 [REQUIRED for all boards and shields]
 // define your port number here, you will need this to open a TCP connection to your Arduino
 #define SERVER_PORT 3030
 
 
-// STEP 5 [REQUIRED for all boards and shields]
+// STEP 6 [REQUIRED for all boards and shields]
 // determine your network security type (OPTION A, B, or C). Option A is the most common, and the
 // default.
 
@@ -200,6 +205,16 @@ char wep_key[] = "your_wep_key";
 #error "you must choose between WIFI_NO_SECURITY and WIFI_WPA_SECURITY"
 #endif
 
+/*==============================================================================
+ * WIFI STREAM (don't change anything here)
+ *============================================================================*/
+
+#ifdef SERVER_IP
+  WiFiClientStream stream(IPAddress(SERVER_IP), SERVER_PORT);
+#else
+  WiFiServerStream stream(SERVER_PORT);
+#endif
+ 
 /*==============================================================================
  * PIN IGNORE MACROS (don't change anything here)
  *============================================================================*/

--- a/utility/WiFiClientStream.h
+++ b/utility/WiFiClientStream.h
@@ -15,12 +15,12 @@
   See file LICENSE.txt for further informations on licensing terms.
 
   Parts of this class are based on
-  
+
   - EthernetClientStream - Copyright (C) 2013 Norbert Truchsess. All rights reserved.
-  
+
   published under the same license.
 
-  Last updated April 15th, 2016
+  Last updated April 17th, 2016
  */
 
 #ifndef WIFI_CLIENT_STREAM_H
@@ -55,8 +55,13 @@ protected:
       if( millis() - _time_connect >= MILLIS_RECONNECT )
       {
         _connected = _client.connect( _remote_ip, _port );
-        if( !_connected ) {
+        if( !_connected )
+        {
           _time_connect = millis();
+        }
+        else if ( _currentHostConnectionCallback )
+        {
+          (*_currentHostConnectionCallback)(HOST_CONNECTION_CONNECTED);
         }
       }
     }
@@ -87,6 +92,10 @@ public:
     if( _client)
     {
       _client.stop();
+      if ( _currentHostConnectionCallback )
+      {
+        (*_currentHostConnectionCallback)(HOST_CONNECTION_DISCONNECTED);
+      }
     }
     _connected = false;
     _time_connect = millis();

--- a/utility/WiFiClientStream.h
+++ b/utility/WiFiClientStream.h
@@ -1,0 +1,97 @@
+/*
+  WiFiClientStream.h
+
+  An Arduino Stream that wraps an instance of a WiFiClient. For use
+  with legacy Arduino WiFi shield and other boards and shields that
+  are compatible with the Arduino WiFi library.
+
+  Copyright (C) 2016 Jens B. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  See file LICENSE.txt for further informations on licensing terms.
+
+  Parts of this class are based on
+  
+  - EthernetClientStream - Copyright (C) 2013 Norbert Truchsess. All rights reserved.
+  
+  published under the same license.
+
+  Last updated April 15th, 2016
+ */
+
+#ifndef WIFI_CLIENT_STREAM_H
+#define WIFI_CLIENT_STREAM_H
+
+#include "WiFiStream.h"
+
+#define MILLIS_RECONNECT 5000
+
+class WiFiClientStream : public WiFiStream
+{
+protected:
+  uint32_t _time_connect = 0;
+
+  /**
+   * check if TCP client is connected
+   * @return true if connected
+   */
+  virtual inline bool connect_client()
+  {
+    if( _client && _client.connected() ) return true;
+
+    if( _connected )
+    {
+      stop();
+    }
+
+    // active TCP connect
+    if( WiFi.status() == WL_CONNECTED )
+    {
+      // if the client is disconnected, try to reconnect every 5 seconds
+      if( millis() - _time_connect >= MILLIS_RECONNECT )
+      {
+        _connected = _client.connect( _remote_ip, _port );
+        if( !_connected ) {
+          _time_connect = millis();
+        }
+      }
+    }
+
+    return _connected;
+  }
+
+public:
+  /**
+   * create a WiFi stream with a TCP client
+   */
+  WiFiClientStream(IPAddress server_ip, uint16_t server_port) : WiFiStream(server_ip, server_port) {}
+
+  /**
+   * maintain WiFi and TCP connection
+   * @return true if WiFi and TCP connection are established
+   */
+  virtual inline bool maintain()
+  {
+    return connect_client();
+  }
+
+  /**
+   * stop client connection
+   */
+  virtual inline void stop()
+  {
+    if( _client)
+    {
+      _client.stop();
+    }
+    _connected = false;
+    _time_connect = millis();
+  }
+
+};
+
+#endif //WIFI_CLIENT_STREAM_H

--- a/utility/WiFiServerStream.h
+++ b/utility/WiFiServerStream.h
@@ -20,7 +20,7 @@
 
   published under the same license.
 
-  Last updated April 16th, 2016
+  Last updated April 17th, 2016
  */
 
 #ifndef WIFI_SERVER_STREAM_H
@@ -49,8 +49,12 @@ protected:
 
     // passive TCP connect (accept)
     WiFiClient newClient = _server.available();
-    if( !_client ) return false;  // could this work on all platforms? if( !(_client && _client.connected()) ) return false;
+    if( !newClient ) return false;
     _client = newClient;
+    if ( _currentHostConnectionCallback )
+    {
+      (*_currentHostConnectionCallback)(HOST_CONNECTION_CONNECTED);
+    }
 
     return true;
   }
@@ -90,6 +94,10 @@ public:
     if( _client)
     {
       _client.stop();
+      if ( _currentHostConnectionCallback )
+      {
+        (*_currentHostConnectionCallback)(HOST_CONNECTION_DISCONNECTED);
+      }
     }
     _connected = false;
   }

--- a/utility/WiFiServerStream.h
+++ b/utility/WiFiServerStream.h
@@ -51,6 +51,7 @@ protected:
     WiFiClient newClient = _server.available();
     if( !newClient ) return false;
     _client = newClient;
+    _connected = true;
     if ( _currentHostConnectionCallback )
     {
       (*_currentHostConnectionCallback)(HOST_CONNECTION_CONNECTED);

--- a/utility/WiFiServerStream.h
+++ b/utility/WiFiServerStream.h
@@ -1,0 +1,98 @@
+/*
+  WiFiServerStream.h
+
+  An Arduino Stream extension for a WiFiClient or WiFiServer to be used
+  with legacy Arduino WiFi shield and other boards and shields that
+  are compatible with the Arduino WiFi library.
+
+  Copyright (C) 2016 Jens B. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  See file LICENSE.txt for further informations on licensing terms.
+
+  Parts of this class are based on
+  
+  - WiFiStream - Copyright (C) 2015-2016 Jesse Frush. All rights reserved.
+  
+  published under the same license.
+
+  Last updated April 15th, 2016
+ */
+
+#ifndef WIFI_SERVER_STREAM_H
+#define WIFI_SERVER_STREAM_H
+
+#include "WiFiStream.h"
+
+class WiFiServerStream : public WiFiStream
+{
+protected:
+  WiFiServer _server = WiFiServer(3030);
+  bool _listening = false;
+
+  /**
+   * check if TCP client is connected
+   * @return true if connected
+   */
+  virtual inline bool connect_client()
+  {
+    if( _client && _client.connected() ) return true;
+
+    if( _connected )
+    {
+      stop();
+    }
+  
+    // passive TCP connect (accept)
+    WiFiClient newClient = _server.available();    
+    if( !_client ) return false;  // could this work on all platforms? if( !(_client && _client.connected()) ) return false;
+    _client = newClient;
+  
+    return true;
+  }
+  
+public:
+  /**
+   * create a WiFi stream with a TCP server
+   */
+  WiFiServerStream(uint16_t server_port) : WiFiStream(server_port), _server(WiFiServer(server_port)) {}
+  
+  /**
+   * maintain WiFi and TCP connection
+   * @return true if WiFi and TCP connection are established
+   */
+  virtual inline bool maintain()
+  {
+    if( connect_client() ) return true;
+
+    stop();
+    
+    if( !_listening && WiFi.status() == WL_CONNECTED )
+    {
+      // start TCP server after first WiFi connect
+      _server.begin();
+      _listening = true;
+    }
+    
+    return false;
+  }
+
+  /**
+   * stop client connection
+   */
+  virtual inline void stop()
+  {
+    if( _client)
+    {
+      _client.stop();
+    }
+    _connected = false;
+  }
+  
+};
+
+#endif //WIFI_SERVER_STREAM_H

--- a/utility/WiFiServerStream.h
+++ b/utility/WiFiServerStream.h
@@ -15,12 +15,12 @@
   See file LICENSE.txt for further informations on licensing terms.
 
   Parts of this class are based on
-  
+
   - WiFiStream - Copyright (C) 2015-2016 Jesse Frush. All rights reserved.
-  
+
   published under the same license.
 
-  Last updated April 15th, 2016
+  Last updated April 16th, 2016
  */
 
 #ifndef WIFI_SERVER_STREAM_H
@@ -46,21 +46,21 @@ protected:
     {
       stop();
     }
-  
+
     // passive TCP connect (accept)
-    WiFiClient newClient = _server.available();    
+    WiFiClient newClient = _server.available();
     if( !_client ) return false;  // could this work on all platforms? if( !(_client && _client.connected()) ) return false;
     _client = newClient;
-  
+
     return true;
   }
-  
+
 public:
   /**
    * create a WiFi stream with a TCP server
    */
-  WiFiServerStream(uint16_t server_port) : WiFiStream(server_port), _server(WiFiServer(server_port)) {}
-  
+  WiFiServerStream(uint16_t server_port) : WiFiStream(server_port) {}
+
   /**
    * maintain WiFi and TCP connection
    * @return true if WiFi and TCP connection are established
@@ -70,14 +70,15 @@ public:
     if( connect_client() ) return true;
 
     stop();
-    
+
     if( !_listening && WiFi.status() == WL_CONNECTED )
     {
       // start TCP server after first WiFi connect
+      _server = WiFiServer(_port);
       _server.begin();
       _listening = true;
     }
-    
+
     return false;
   }
 
@@ -92,7 +93,7 @@ public:
     }
     _connected = false;
   }
-  
+
 };
 
 #endif //WIFI_SERVER_STREAM_H

--- a/utility/WiFiStream.h
+++ b/utility/WiFiStream.h
@@ -1,10 +1,12 @@
 /*
   WiFiStream.h
-  An Arduino Stream that wraps an instance of a WiFi server. For use
+
+  An Arduino Stream extension for a WiFiClient or WiFiServer to be used
   with legacy Arduino WiFi shield and other boards and shields that
   are compatible with the Arduino WiFi library.
 
   Copyright (C) 2015-2016 Jesse Frush. All rights reserved.
+  Copyright (C) 2016      Jens B. All rights reserved.
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -13,9 +15,9 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated April 10th, 2016
+  Last updated April 15th, 2016
  */
-
+ 
 #ifndef WIFI_STREAM_H
 #define WIFI_STREAM_H
 
@@ -24,57 +26,44 @@
 
 class WiFiStream : public Stream
 {
-private:
-  WiFiServer _server = WiFiServer(23);
+protected:
   WiFiClient _client;
+  bool _connected = false;
 
   //configuration members
-  IPAddress _local_ip;
-  IPAddress _gateway;
+  IPAddress _local_ip;                // DHCP
   IPAddress _subnet;
-  uint16_t _port = 0;
-  uint8_t _key_idx = 0;               //WEP
+  IPAddress _gateway;
+  IPAddress _remote_ip;
+  uint16_t _port;
+  uint8_t _key_idx;                   //WEP
   const char *_key = nullptr;         //WEP
   const char *_passphrase = nullptr;  //WPA
   char *_ssid = nullptr;
-  bool _new_connection = false;
 
-  inline int connect_client()
-  {
-    if( !( _client && _client.connected() ) )
-    {
-      WiFiClient newClient = _server.available();
-      if( !newClient )
-      {
-        return 0;
-      }
-
-      _client = newClient;
-    }
-    return 1;
-  }
-
-  inline bool is_new_connection()
-  {
-    if (_new_connection && WiFi.status() == WL_CONNECTED) {
-      _new_connection = false;
-      return true;
-    }
-    _new_connection = true;
-    return false;
-  }
-
-  inline bool is_ready()
-  {
-    uint8_t status = WiFi.status();
-    return !( status == WL_NO_SHIELD || status == WL_CONNECTED );
-  }
+  /**
+   * check if TCP client is connected
+   * @return true if connected
+   */
+  virtual bool connect_client() = 0;
 
 public:
-  WiFiStream() {};
+  /** constructor for TCP server */
+  WiFiStream(uint16_t server_port) : _port(server_port) {}
+
+  /** constructor for TCP client */
+  WiFiStream(IPAddress server_ip, uint16_t server_port) : _remote_ip(server_ip), _port(server_port) {}
+
+
+/******************************************************************************
+ *           network configuration
+ ******************************************************************************/
 
 #ifndef ESP8266
-  // allows another way to configure a static IP before begin is called
+  /**
+   * configure a static local IP address without defining the local network
+   * DHCP will be used as long as local IP address is not defined
+   */
   inline void config(IPAddress local_ip)
   {
     _local_ip = local_ip;
@@ -82,12 +71,15 @@ public:
   }
 #endif
 
-  // allows another way to configure a static IP before begin is called
+  /**
+   * configure a static local IP address
+   * DHCP will be used as long as local IP address is not defined
+   */
   inline void config(IPAddress local_ip, IPAddress gateway, IPAddress subnet)
   {
     _local_ip = local_ip;
-    _gateway = gateway;
     _subnet = subnet;
+    _gateway = gateway;
 #ifndef ESP8266
     WiFi.config( local_ip, IPAddress(0, 0, 0, 0), gateway, subnet );
 #else
@@ -95,200 +87,81 @@ public:
 #endif
   }
 
-  // get DCHP IP
-  inline IPAddress localIP()
+  /**
+   * @return local IP address
+   */
+  inline IPAddress getLocalIP()
   {
     return WiFi.localIP();
   }
 
+/******************************************************************************
+ *           network functions
+ ******************************************************************************/
+
   /**
-   * @return true if connected
+   * maintain WiFi and TCP connection
+   * @return true if WiFi and TCP connection are established
    */
-  inline bool maintain()
-  {
-    if( connect_client() ) return true;
+  virtual bool maintain() = 0;
 
-    stop();
-    int result = 0;
-    if( WiFi.status() != WL_CONNECTED )
-    {
-      if( _local_ip )
-      {
-#ifndef ESP8266
-        WiFi.config( _local_ip );
-#else
-        WiFi.config( _local_ip, _gateway, _subnet );
-#endif
-      }
-
-      if( _passphrase )
-      {
-#ifndef ESP8266
-        result = WiFi.begin( _ssid, _passphrase);
-#else
-        WiFi.begin( _ssid, _passphrase);
-        result = WiFi.status();
-#endif
-      }
-#ifndef ESP8266
-      else if( _key_idx && _key )
-      {
-        result = WiFi.begin( _ssid, _key_idx, _key );
-      }
-#endif
-      else
-      {
-#ifndef ESP8266
-        result = WiFi.begin( _ssid);
-#else
-        WiFi.begin( _ssid);
-        result = WiFi.status();
-#endif
-      }
-    }
-    if( result == 0 ) return false;
-
-    _server = WiFiServer( _port );
-    _server.begin();
-    return result;
-  }
+  /**
+   * close TCP client connection
+   */
+  virtual void stop() = 0;
 
 /******************************************************************************
- *           Connection functions with DHCP
+ *           WiFi configuration
  ******************************************************************************/
 
-  //OPEN networks
-  inline int begin(char *ssid, uint16_t port)
+  /**
+   * initialize WiFi without security (open) and initiate client connection
+   * if WiFi connection is already established
+   * @return WL_CONNECTED if WiFi connection is established
+   */
+  inline int begin(char *ssid)
   {
-    if( is_new_connection() ) return WL_CONNECTED;
-    if( !is_ready() ) return 0;
-
     _ssid = ssid;
-    _port = port;
 
-    int result = WiFi.begin(ssid);
-    // will always return 0 for ESP8266
-    if( result == 0 ) return 0;
-
-    _server = WiFiServer( port );
-    _server.begin();
-    return result;
+    WiFi.begin(ssid);
+    int result = WiFi.status();
+    return WiFi.status();
   }
 
 #ifndef ESP8266
-  //WEP-encrypted networks
-  inline int begin(char *ssid, uint8_t key_idx, const char *key, uint16_t port)
+  /**
+   * initialize WiFi with WEP security and initiate client connection
+   * if WiFi connection is already established
+   * @return WL_CONNECTED if WiFi connection is established
+   */
+  inline int begin(char *ssid, uint8_t key_idx, const char *key)
   {
-    if( is_new_connection() ) return WL_CONNECTED;
-    if( !is_ready() ) return 0;
-
     _ssid = ssid;
-    _port = port;
     _key_idx = key_idx;
     _key = key;
 
-    int result = WiFi.begin( ssid, key_idx, key );
-    if( result == 0 ) return 0;
-
-    _server = WiFiServer( port );
-    _server.begin();
-    return result;
+    WiFi.begin( ssid, key_idx, key );
+    return WiFi.status();
   }
 #endif
 
-  //WPA-encrypted networks
-  inline int begin(char *ssid, const char *passphrase, uint16_t port)
+  /**
+   * initialize WiFi with WPA-PSK security and initiate client connection
+   * if WiFi connection is already established
+   * @return WL_CONNECTED if WiFi connection is established
+   */
+  inline int begin(char *ssid, const char *passphrase)
   {
-    // TODO - figure out a cleaner way to handle this. The issue is that with the ESP8266
-    // WiFi.begin does not wait so the connect state is is therefore not updated until the
-    // next time begin is called. The call to !is_ready() below however returns 0 if
-    // WL_CONNECTED is true. This is to allow a new connection with different parameters than
-    // the original connection. is_new_connection is a temporary solution.
-    if( is_new_connection() ) return WL_CONNECTED;
-    if( !is_ready() ) return 0;
-
     _ssid = ssid;
-    _port = port;
     _passphrase = passphrase;
 
-    int result = WiFi.begin(ssid, passphrase);
-    // will always return 0 for ESP8266
-    if( result == 0 ) return 0;
-
-    _server = WiFiServer( port );
-    _server.begin();
-    return result;
+    WiFi.begin(ssid, passphrase);
+    return WiFi.status();
   }
+
 
 /******************************************************************************
- *           Connection functions without DHCP
- ******************************************************************************/
-
-// ESP8266 requires gateway and subnet so the following functions are not compatible
-#ifndef ESP8266
-  //OPEN networks with static IP
-  inline int begin(char *ssid, IPAddress local_ip, uint16_t port)
-  {
-    if( is_new_connection() ) return WL_CONNECTED;
-    if( !is_ready() ) return 0;
-
-    _ssid = ssid;
-    _port = port;
-    _local_ip = local_ip;
-
-    WiFi.config( local_ip );
-    int result = WiFi.begin( ssid );
-    if( result == 0 ) return 0;
-
-    _server = WiFiServer( port );
-    _server.begin();
-    return result;
-  }
-
-  //WEP-encrypted networks with static IP
-  inline int begin(char *ssid, IPAddress local_ip, uint8_t key_idx, const char *key, uint16_t port)
-  {
-    if( is_new_connection() ) return WL_CONNECTED;
-    if( !is_ready() ) return 0;
-
-    _ssid = ssid;
-    _port = port;
-    _local_ip = local_ip;
-    _key_idx = key_idx;
-    _key = key;
-
-    WiFi.config( local_ip );
-    int result = WiFi.begin( ssid, key_idx, key );
-    if( result == 0 ) return 0;
-
-    _server = WiFiServer( port );
-    _server.begin();
-    return result;
-  }
-
-  //WPA-encrypted networks with static IP
-  inline int begin(char *ssid, IPAddress local_ip, const char *passphrase, uint16_t port)
-  {
-    if( is_new_connection() ) return WL_CONNECTED;
-    if( !is_ready() ) return 0;
-
-    _ssid = ssid;
-    _port = port;
-    _local_ip = local_ip;
-    _passphrase = passphrase;
-
-    WiFi.config( local_ip );
-    int result = WiFi.begin( ssid, passphrase);
-    if( result == 0 ) return 0;
-
-    _server = WiFiServer( port );
-    _server.begin();
-    return result;
-  }
-#endif
-
-/******************************************************************************
- *             Stream implementations
+ *             stream functions
  ******************************************************************************/
 
   inline int available()
@@ -311,15 +184,11 @@ public:
     return connect_client() ? _client.read() : -1;
   }
 
-  inline void stop()
-  {
-    _client.stop();
-  }
-
   inline size_t write(uint8_t byte)
   {
-    if( connect_client() ) _client.write( byte );
+    return connect_client() ? _client.write( byte ) : 0;
   }
+
 };
 
 #endif //WIFI_STREAM_H

--- a/utility/WiFiStream.h
+++ b/utility/WiFiStream.h
@@ -15,20 +15,29 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated April 15th, 2016
+  Last updated April 17th, 2016
  */
- 
+
 #ifndef WIFI_STREAM_H
 #define WIFI_STREAM_H
 
 #include <inttypes.h>
 #include <Stream.h>
 
+#define HOST_CONNECTION_DISCONNECTED 0
+#define HOST_CONNECTION_CONNECTED    1
+
+extern "C" {
+  // callback function types
+  typedef void (*hostConnectionCallbackFunction)(byte);
+}
+
 class WiFiStream : public Stream
 {
 protected:
   WiFiClient _client;
   bool _connected = false;
+  hostConnectionCallbackFunction _currentHostConnectionCallback;
 
   //configuration members
   IPAddress _local_ip;                // DHCP
@@ -54,6 +63,7 @@ public:
   /** constructor for TCP client */
   WiFiStream(IPAddress server_ip, uint16_t server_port) : _remote_ip(server_ip), _port(server_port) {}
 
+  inline void attach( hostConnectionCallbackFunction newFunction ) { _currentHostConnectionCallback = newFunction; }
 
 /******************************************************************************
  *           network configuration


### PR DESCRIPTION
Changes
- server related functions moved from WiFiStream into WiFiServerStream
- unified class interface for sketch file (no client/server defines)
- WiFi and TCP configuration and connect split into individual methods (TCP constructor, static IP config, WiFi begin and TCP maintain)
- WiFi only initialized once at startup (WiFi connections cannot be forced by repeatedly calling begin)
- convenience methods for combined WiFi/network initialization removed

Tests
- tested with Huzzah ESP8266 in client mode
- successfully builds for AVR architecture with legacy WiFi option

Todo
- decide if inheritance from new WiFiStream is preferable to copied code in two classes in regard to code efficiency, code size, platform compatibility and maintenance
- decide if a single client/server class would be preferable to separate classes in regard to code efficiency, code size and maintenance

The approach used in this PR could be applied to EthernetClientStream to provide the missing EthernetServerStream. Basically its the same without the WiFi parts.