### PR TITLE
connection state management modified

### DIFF
--- a/utility/WiFiClientStream.h
+++ b/utility/WiFiClientStream.h
@@ -20,7 +20,7 @@
 
   published under the same license.
 
-  Last updated April 17th, 2016
+  Last updated April 23rd, 2016
  */
 
 #ifndef WIFI_CLIENT_STREAM_H
@@ -41,21 +41,20 @@ protected:
    */
   virtual inline bool connect_client()
   {
-    if( _client && _client.connected() ) return true;
-
-    if( _connected )
+    if ( _connected )
     {
+      if ( _client && _client.connected() ) return true;
       stop();
     }
 
     // active TCP connect
-    if( WiFi.status() == WL_CONNECTED )
+    if ( WiFi.status() == WL_CONNECTED )
     {
       // if the client is disconnected, try to reconnect every 5 seconds
-      if( millis() - _time_connect >= MILLIS_RECONNECT )
+      if ( millis() - _time_connect >= MILLIS_RECONNECT )
       {
         _connected = _client.connect( _remote_ip, _port );
-        if( !_connected )
+        if ( !_connected )
         {
           _time_connect = millis();
         }
@@ -89,7 +88,7 @@ public:
    */
   virtual inline void stop()
   {
-    if( _client)
+    if ( _client)
     {
       _client.stop();
       if ( _currentHostConnectionCallback )

--- a/utility/WiFiServerStream.h
+++ b/utility/WiFiServerStream.h
@@ -20,7 +20,7 @@
 
   published under the same license.
 
-  Last updated April 17th, 2016
+  Last updated April 23rd, 2016
  */
 
 #ifndef WIFI_SERVER_STREAM_H
@@ -40,16 +40,15 @@ protected:
    */
   virtual inline bool connect_client()
   {
-    if( _client && _client.connected() ) return true;
-
-    if( _connected )
+    if ( _connected )
     {
+      if ( _client && _client.connected() ) return true;
       stop();
     }
 
     // passive TCP connect (accept)
     WiFiClient newClient = _server.available();
-    if( !newClient ) return false;
+    if ( !newClient ) return false;
     _client = newClient;
     _connected = true;
     if ( _currentHostConnectionCallback )
@@ -72,11 +71,11 @@ public:
    */
   virtual inline bool maintain()
   {
-    if( connect_client() ) return true;
+    if ( connect_client() ) return true;
 
     stop();
 
-    if( !_listening && WiFi.status() == WL_CONNECTED )
+    if ( !_listening && WiFi.status() == WL_CONNECTED )
     {
       // start TCP server after first WiFi connect
       _server = WiFiServer(_port);
@@ -92,7 +91,7 @@ public:
    */
   virtual inline void stop()
   {
-    if( _client)
+    if ( _client)
     {
       _client.stop();
       if ( _currentHostConnectionCallback )

--- a/utility/WiFiStream.h
+++ b/utility/WiFiStream.h
@@ -15,7 +15,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated April 17th, 2016
+  Last updated April 23rd, 2016
  */
 
 #ifndef WIFI_STREAM_H
@@ -114,6 +114,28 @@ public:
    * @return true if WiFi and TCP connection are established
    */
   virtual bool maintain() = 0;
+  
+#ifdef ESP8266
+  /**
+   * get status of TCP connection
+   * @return status of TCP connection
+   *         CLOSED      = 0 (typical)
+   *         LISTEN      = 1 (not used)
+   *         SYN_SENT    = 2
+   *         SYN_RCVD    = 3
+   *         ESTABLISHED = 4 (typical)
+   *         FIN_WAIT_1  = 5
+   *         FIN_WAIT_2  = 6
+   *         CLOSE_WAIT  = 7
+   *         CLOSING     = 8
+   *         LAST_ACK    = 9
+   *         TIME_WAIT   = 10
+   */
+  inline uint8_t status() 
+  {
+    return _client.status();
+  }
+#endif
 
   /**
    * close TCP client connection


### PR DESCRIPTION
- check member _connected first in connect_client() to prevent querying
connected() of disconnected _client
- added method status() to check TCP connection state (ESP8266 only)