### PR TITLE
Update url of ThomasWeinert/carica-firmata

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ Most of the time you will be interacting with Arduino with a client library on t
   * [http://funnel.cc]
   * [http://code.google.com/p/as3glue/]
 * PHP
-  * [https://bitbucket.org/ThomasWeinert/carica-firmata]
+  * [https://github.com/ThomasWeinert/carica-firmata]
   * [https://github.com/oasynnoum/phpmake_firmata]
 * Haskell
   * [http://hackage.haskell.org/package/hArduino]


### PR DESCRIPTION
Bitbucket repository [says](https://bitbucket.org/thomasweinert/carica-firmata/src) that it was moved to the GitHub. This pull request actualizes the URL.