### PR TITLE
Fix compiler issues for older Arduino IDE versions

### DIFF
--- a/Firmata.cpp
+++ b/Firmata.cpp
@@ -65,6 +65,7 @@ FirmataClass::FirmataClass()
 {
   firmwareVersionCount = 0;
   firmwareVersionVector = 0;
+  blinkVersionDisabled = false;
   systemReset();
 }
 

--- a/Firmata.h
+++ b/Firmata.h
@@ -1,7 +1,7 @@
 /*
   Firmata.h - Firmata library v2.5.3 - 2016-06-18
   Copyright (c) 2006-2008 Hans-Christoph Steiner.  All rights reserved.
-  Copyright (C) 2009-2015 Jeff Hoefs.  All rights reserved.
+  Copyright (C) 2009-2016 Jeff Hoefs.  All rights reserved.
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -201,7 +201,7 @@ class FirmataClass
     stringCallbackFunction currentStringCallback;
     sysexCallbackFunction currentSysexCallback;
 
-    boolean blinkVersionDisabled = false;
+    boolean blinkVersionDisabled;
 
     /* private methods ------------------------------ */
     void processSysexMessage(void);

--- a/examples/StandardFirmata/StandardFirmata.ino
+++ b/examples/StandardFirmata/StandardFirmata.ino
@@ -91,6 +91,8 @@ byte servoCount = 0;
 
 boolean isResetting = false;
 
+// Forward declare a few functions to avoid compiler errors with older versions
+// of the Arduino IDE.
 void setPinModeCallback(byte, int);
 void reportAnalogCallback(byte analogPin, int value);
 void sysexCallback(byte, byte, byte*);

--- a/examples/StandardFirmata/StandardFirmata.ino
+++ b/examples/StandardFirmata/StandardFirmata.ino
@@ -20,7 +20,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated by Jeff Hoefs: January 10th, 2016
+  Last updated October 16th, 2016
 */
 
 #include <Servo.h>
@@ -91,6 +91,9 @@ byte servoCount = 0;
 
 boolean isResetting = false;
 
+void setPinModeCallback(byte, int);
+void reportAnalogCallback(byte analogPin, int value);
+void sysexCallback(byte, byte, byte*);
 
 /* utility functions */
 void wireWrite(byte data)
@@ -151,6 +154,30 @@ void detachServo(byte pin)
   }
 
   servoPinMap[pin] = 255;
+}
+
+void enableI2CPins()
+{
+  byte i;
+  // is there a faster way to do this? would probaby require importing
+  // Arduino.h to get SCL and SDA pins
+  for (i = 0; i < TOTAL_PINS; i++) {
+    if (IS_PIN_I2C(i)) {
+      // mark pins as i2c so they are ignore in non i2c data requests
+      setPinModeCallback(i, PIN_MODE_I2C);
+    }
+  }
+
+  isI2CEnabled = true;
+
+  Wire.begin();
+}
+
+/* disable the i2c pins so they can be used for other functions */
+void disableI2CPins() {
+  isI2CEnabled = false;
+  // disable read continuous mode for all devices
+  queryIndex = -1;
 }
 
 void readAndReportData(byte address, int theRegister, byte numBytes, byte stopTX) {
@@ -662,30 +689,6 @@ void sysexCallback(byte command, byte argc, byte *argv)
 #endif
       break;
   }
-}
-
-void enableI2CPins()
-{
-  byte i;
-  // is there a faster way to do this? would probaby require importing
-  // Arduino.h to get SCL and SDA pins
-  for (i = 0; i < TOTAL_PINS; i++) {
-    if (IS_PIN_I2C(i)) {
-      // mark pins as i2c so they are ignore in non i2c data requests
-      setPinModeCallback(i, PIN_MODE_I2C);
-    }
-  }
-
-  isI2CEnabled = true;
-
-  Wire.begin();
-}
-
-/* disable the i2c pins so they can be used for other functions */
-void disableI2CPins() {
-  isI2CEnabled = false;
-  // disable read continuous mode for all devices
-  queryIndex = -1;
 }
 
 /*==============================================================================

--- a/examples/StandardFirmataBLE/StandardFirmataBLE.ino
+++ b/examples/StandardFirmataBLE/StandardFirmataBLE.ino
@@ -34,6 +34,8 @@
  * Uncomment the following include to enable interfacing
  * with Serial devices via hardware or software serial.
  */
+// In order to use software serial, you will need to compile this sketch with
+// Arduino IDE v1.6.6 or higher. Hardware serial should work back to Arduino 1.0.
 //#include "utility/SerialFirmata.h"
 
 // follow the instructions in bleConfig.h to configure your BLE hardware

--- a/examples/StandardFirmataBLE/StandardFirmataBLE.ino
+++ b/examples/StandardFirmataBLE/StandardFirmataBLE.ino
@@ -108,6 +108,8 @@ byte servoCount = 0;
 
 boolean isResetting = false;
 
+// Forward declare a few functions to avoid compiler errors with older versions
+// of the Arduino IDE.
 void setPinModeCallback(byte, int);
 void reportAnalogCallback(byte analogPin, int value);
 void sysexCallback(byte, byte, byte*);

--- a/examples/StandardFirmataBLE/StandardFirmataBLE.ino
+++ b/examples/StandardFirmataBLE/StandardFirmataBLE.ino
@@ -20,7 +20,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated June 15th, 2016
+  Last updated October 16th, 2016
 */
 
 #include <Servo.h>
@@ -108,6 +108,10 @@ byte servoCount = 0;
 
 boolean isResetting = false;
 
+void setPinModeCallback(byte, int);
+void reportAnalogCallback(byte analogPin, int value);
+void sysexCallback(byte, byte, byte*);
+
 /* utility functions */
 void wireWrite(byte data)
 {
@@ -167,6 +171,30 @@ void detachServo(byte pin)
   }
 
   servoPinMap[pin] = 255;
+}
+
+void enableI2CPins()
+{
+  byte i;
+  // is there a faster way to do this? would probaby require importing
+  // Arduino.h to get SCL and SDA pins
+  for (i = 0; i < TOTAL_PINS; i++) {
+    if (IS_PIN_I2C(i)) {
+      // mark pins as i2c so they are ignore in non i2c data requests
+      setPinModeCallback(i, PIN_MODE_I2C);
+    }
+  }
+
+  isI2CEnabled = true;
+
+  Wire.begin();
+}
+
+/* disable the i2c pins so they can be used for other functions */
+void disableI2CPins() {
+  isI2CEnabled = false;
+  // disable read continuous mode for all devices
+  queryIndex = -1;
 }
 
 void readAndReportData(byte address, int theRegister, byte numBytes, byte stopTX) {
@@ -678,30 +706,6 @@ void sysexCallback(byte command, byte argc, byte *argv)
 #endif
       break;
   }
-}
-
-void enableI2CPins()
-{
-  byte i;
-  // is there a faster way to do this? would probaby require importing
-  // Arduino.h to get SCL and SDA pins
-  for (i = 0; i < TOTAL_PINS; i++) {
-    if (IS_PIN_I2C(i)) {
-      // mark pins as i2c so they are ignore in non i2c data requests
-      setPinModeCallback(i, PIN_MODE_I2C);
-    }
-  }
-
-  isI2CEnabled = true;
-
-  Wire.begin();
-}
-
-/* disable the i2c pins so they can be used for other functions */
-void disableI2CPins() {
-  isI2CEnabled = false;
-  // disable read continuous mode for all devices
-  queryIndex = -1;
 }
 
 /*==============================================================================

--- a/examples/StandardFirmataChipKIT/StandardFirmataChipKIT.ino
+++ b/examples/StandardFirmataChipKIT/StandardFirmataChipKIT.ino
@@ -88,6 +88,8 @@ byte servoCount = 0;
 
 boolean isResetting = false;
 
+// Forward declare a few functions to avoid compiler errors with older versions
+// of the Arduino IDE.
 void setPinModeCallback(byte, int);
 void reportAnalogCallback(byte analogPin, int value);
 void sysexCallback(byte, byte, byte*);

--- a/examples/StandardFirmataChipKIT/StandardFirmataChipKIT.ino
+++ b/examples/StandardFirmataChipKIT/StandardFirmataChipKIT.ino
@@ -21,7 +21,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated by Jeff Hoefs: January 10th, 2016
+  Last updated October 16th, 2016
 */
 
 #include <SoftPWMServo.h>  // Gives us PWM and Servo on every pin
@@ -88,6 +88,10 @@ byte servoCount = 0;
 
 boolean isResetting = false;
 
+void setPinModeCallback(byte, int);
+void reportAnalogCallback(byte analogPin, int value);
+void sysexCallback(byte, byte, byte*);
+
 /* utility functions */
 void wireWrite(byte data)
 {
@@ -147,6 +151,30 @@ void detachServo(byte pin)
   }
 
   servoPinMap[pin] = 255;
+}
+
+void enableI2CPins()
+{
+  byte i;
+  // is there a faster way to do this? would probaby require importing
+  // Arduino.h to get SCL and SDA pins
+  for (i = 0; i < TOTAL_PINS; i++) {
+    if (IS_PIN_I2C(i)) {
+      // mark pins as i2c so they are ignore in non i2c data requests
+      setPinModeCallback(i, PIN_MODE_I2C);
+    }
+  }
+
+  isI2CEnabled = true;
+
+  Wire.begin();
+}
+
+/* disable the i2c pins so they can be used for other functions */
+void disableI2CPins() {
+  isI2CEnabled = false;
+  // disable read continuous mode for all devices
+  queryIndex = -1;
 }
 
 void readAndReportData(byte address, int theRegister, byte numBytes, byte stopTX) {
@@ -654,30 +682,6 @@ void sysexCallback(byte command, byte argc, byte *argv)
       Firmata.write(END_SYSEX);
       break;
   }
-}
-
-void enableI2CPins()
-{
-  byte i;
-  // is there a faster way to do this? would probaby require importing
-  // Arduino.h to get SCL and SDA pins
-  for (i = 0; i < TOTAL_PINS; i++) {
-    if (IS_PIN_I2C(i)) {
-      // mark pins as i2c so they are ignore in non i2c data requests
-      setPinModeCallback(i, PIN_MODE_I2C);
-    }
-  }
-
-  isI2CEnabled = true;
-
-  Wire.begin();
-}
-
-/* disable the i2c pins so they can be used for other functions */
-void disableI2CPins() {
-  isI2CEnabled = false;
-  // disable read continuous mode for all devices
-  queryIndex = -1;
 }
 
 /*==============================================================================

--- a/examples/StandardFirmataEthernet/StandardFirmataEthernet.ino
+++ b/examples/StandardFirmataEthernet/StandardFirmataEthernet.ino
@@ -20,7 +20,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated by Jeff Hoefs: June 18th, 2016
+  Last updated October 16th, 2016
 */
 
 /*
@@ -161,6 +161,10 @@ byte servoCount = 0;
 
 boolean isResetting = false;
 
+void setPinModeCallback(byte, int);
+void reportAnalogCallback(byte analogPin, int value);
+void sysexCallback(byte, byte, byte*);
+
 /* utility functions */
 void wireWrite(byte data)
 {
@@ -220,6 +224,30 @@ void detachServo(byte pin)
   }
 
   servoPinMap[pin] = 255;
+}
+
+void enableI2CPins()
+{
+  byte i;
+  // is there a faster way to do this? would probaby require importing
+  // Arduino.h to get SCL and SDA pins
+  for (i = 0; i < TOTAL_PINS; i++) {
+    if (IS_PIN_I2C(i)) {
+      // mark pins as i2c so they are ignore in non i2c data requests
+      setPinModeCallback(i, PIN_MODE_I2C);
+    }
+  }
+
+  isI2CEnabled = true;
+
+  Wire.begin();
+}
+
+/* disable the i2c pins so they can be used for other functions */
+void disableI2CPins() {
+  isI2CEnabled = false;
+  // disable read continuous mode for all devices
+  queryIndex = -1;
 }
 
 void readAndReportData(byte address, int theRegister, byte numBytes, byte stopTX) {
@@ -732,30 +760,6 @@ void sysexCallback(byte command, byte argc, byte *argv)
 #endif
       break;
   }
-}
-
-void enableI2CPins()
-{
-  byte i;
-  // is there a faster way to do this? would probaby require importing
-  // Arduino.h to get SCL and SDA pins
-  for (i = 0; i < TOTAL_PINS; i++) {
-    if (IS_PIN_I2C(i)) {
-      // mark pins as i2c so they are ignore in non i2c data requests
-      setPinModeCallback(i, PIN_MODE_I2C);
-    }
-  }
-
-  isI2CEnabled = true;
-
-  Wire.begin();
-}
-
-/* disable the i2c pins so they can be used for other functions */
-void disableI2CPins() {
-  isI2CEnabled = false;
-  // disable read continuous mode for all devices
-  queryIndex = -1;
 }
 
 /*==============================================================================

--- a/examples/StandardFirmataEthernet/StandardFirmataEthernet.ino
+++ b/examples/StandardFirmataEthernet/StandardFirmataEthernet.ino
@@ -161,6 +161,8 @@ byte servoCount = 0;
 
 boolean isResetting = false;
 
+// Forward declare a few functions to avoid compiler errors with older versions
+// of the Arduino IDE.
 void setPinModeCallback(byte, int);
 void reportAnalogCallback(byte analogPin, int value);
 void sysexCallback(byte, byte, byte*);

--- a/examples/StandardFirmataEthernet/StandardFirmataEthernet.ino
+++ b/examples/StandardFirmataEthernet/StandardFirmataEthernet.ino
@@ -78,6 +78,8 @@
  * remaining to reliably run Firmata. Arduino Yun is okay because it doesn't import the Ethernet
  * libraries.
  */
+// In order to use software serial, you will need to compile this sketch with
+// Arduino IDE v1.6.6 or higher. Hardware serial should work back to Arduino 1.0.
 //#include "utility/SerialFirmata.h"
 
 #define I2C_WRITE                   B00000000

--- a/examples/StandardFirmataPlus/StandardFirmataPlus.ino
+++ b/examples/StandardFirmataPlus/StandardFirmataPlus.ino
@@ -116,6 +116,8 @@ byte servoCount = 0;
 
 boolean isResetting = false;
 
+// Forward declare a few functions to avoid compiler errors with older versions
+// of the Arduino IDE.
 void setPinModeCallback(byte, int);
 void reportAnalogCallback(byte analogPin, int value);
 void sysexCallback(byte, byte, byte*);

--- a/examples/StandardFirmataPlus/StandardFirmataPlus.ino
+++ b/examples/StandardFirmataPlus/StandardFirmataPlus.ino
@@ -116,6 +116,9 @@ byte servoCount = 0;
 
 boolean isResetting = false;
 
+void setPinModeCallback(byte, int);
+void reportAnalogCallback(byte analogPin, int value);
+void sysexCallback(byte, byte, byte*);
 
 /* utility functions */
 void wireWrite(byte data)
@@ -176,6 +179,30 @@ void detachServo(byte pin)
   }
 
   servoPinMap[pin] = 255;
+}
+
+void enableI2CPins()
+{
+  byte i;
+  // is there a faster way to do this? would probaby require importing
+  // Arduino.h to get SCL and SDA pins
+  for (i = 0; i < TOTAL_PINS; i++) {
+    if (IS_PIN_I2C(i)) {
+      // mark pins as i2c so they are ignore in non i2c data requests
+      setPinModeCallback(i, PIN_MODE_I2C);
+    }
+  }
+
+  isI2CEnabled = true;
+
+  Wire.begin();
+}
+
+/* disable the i2c pins so they can be used for other functions */
+void disableI2CPins() {
+  isI2CEnabled = false;
+  // disable read continuous mode for all devices
+  queryIndex = -1;
 }
 
 void readAndReportData(byte address, int theRegister, byte numBytes, byte stopTX) {
@@ -687,30 +714,6 @@ void sysexCallback(byte command, byte argc, byte *argv)
 #endif
       break;
   }
-}
-
-void enableI2CPins()
-{
-  byte i;
-  // is there a faster way to do this? would probaby require importing
-  // Arduino.h to get SCL and SDA pins
-  for (i = 0; i < TOTAL_PINS; i++) {
-    if (IS_PIN_I2C(i)) {
-      // mark pins as i2c so they are ignore in non i2c data requests
-      setPinModeCallback(i, PIN_MODE_I2C);
-    }
-  }
-
-  isI2CEnabled = true;
-
-  Wire.begin();
-}
-
-/* disable the i2c pins so they can be used for other functions */
-void disableI2CPins() {
-  isI2CEnabled = false;
-  // disable read continuous mode for all devices
-  queryIndex = -1;
 }
 
 /*==============================================================================

--- a/examples/StandardFirmataPlus/StandardFirmataPlus.ino
+++ b/examples/StandardFirmataPlus/StandardFirmataPlus.ino
@@ -20,7 +20,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated by Jeff Hoefs: January 10th, 2016
+  Last updated October 16th, 2016
 */
 
 /*
@@ -36,6 +36,9 @@
   - Ability to interface with serial devices using UART, USART, or SoftwareSerial
     depending on the capatilities of the board.
 
+  NOTE: In order to use SoftwareSerial with the Firmata Serial feature,
+  StandardFirmataPlus must be compiled with Arduino v1.6.6 or newer.
+
   At the time of this writing, StandardFirmataPlus will still compile and run
   on ATMega328p and ATMega32u4-based boards, but future versions of this sketch
   may not as new features are added.
@@ -45,6 +48,8 @@
 #include <Wire.h>
 #include <Firmata.h>
 
+// In order to use software serial, you will need to compile this sketch with
+// Arduino IDE v1.6.6 or higher. Hardware serial should work back to Arduino 1.0.
 #include "utility/SerialFirmata.h"
 
 #define I2C_WRITE                   B00000000

--- a/examples/StandardFirmataWiFi/StandardFirmataWiFi.ino
+++ b/examples/StandardFirmataWiFi/StandardFirmataWiFi.ino
@@ -174,6 +174,8 @@ byte servoCount = 0;
 
 boolean isResetting = false;
 
+// Forward declare a few functions to avoid compiler errors with older versions
+// of the Arduino IDE.
 void setPinModeCallback(byte, int);
 void reportAnalogCallback(byte analogPin, int value);
 void sysexCallback(byte, byte, byte*);

--- a/examples/StandardFirmataWiFi/StandardFirmataWiFi.ino
+++ b/examples/StandardFirmataWiFi/StandardFirmataWiFi.ino
@@ -89,6 +89,8 @@
  * Uncomment the following include to enable interfacing with Serial devices via hardware or
  * software serial.
  */
+// In order to use software serial, you will need to compile this sketch with
+// Arduino IDE v1.6.6 or higher. Hardware serial should work back to Arduino 1.0.
 //#include "utility/SerialFirmata.h"
 
 // follow the instructions in wifiConfig.h to configure your particular hardware

--- a/examples/StandardFirmataWiFi/StandardFirmataWiFi.ino
+++ b/examples/StandardFirmataWiFi/StandardFirmataWiFi.ino
@@ -22,7 +22,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated by Jeff Hoefs: April 24th, 2016
+  Last updated October 16th, 2016
 */
 
 /*
@@ -174,6 +174,10 @@ byte servoCount = 0;
 
 boolean isResetting = false;
 
+void setPinModeCallback(byte, int);
+void reportAnalogCallback(byte analogPin, int value);
+void sysexCallback(byte, byte, byte*);
+
 /* utility functions */
 void wireWrite(byte data)
 {
@@ -233,6 +237,30 @@ void detachServo(byte pin)
   }
 
   servoPinMap[pin] = 255;
+}
+
+void enableI2CPins()
+{
+  byte i;
+  // is there a faster way to do this? would probaby require importing
+  // Arduino.h to get SCL and SDA pins
+  for (i = 0; i < TOTAL_PINS; i++) {
+    if (IS_PIN_I2C(i)) {
+      // mark pins as i2c so they are ignore in non i2c data requests
+      setPinModeCallback(i, PIN_MODE_I2C);
+    }
+  }
+
+  isI2CEnabled = true;
+
+  Wire.begin();
+}
+
+/* disable the i2c pins so they can be used for other functions */
+void disableI2CPins() {
+  isI2CEnabled = false;
+  // disable read continuous mode for all devices
+  queryIndex = -1;
 }
 
 void readAndReportData(byte address, int theRegister, byte numBytes, byte stopTX) {
@@ -750,30 +778,6 @@ void sysexCallback(byte command, byte argc, byte *argv)
 #endif
       break;
   }
-}
-
-void enableI2CPins()
-{
-  byte i;
-  // is there a faster way to do this? would probaby require importing
-  // Arduino.h to get SCL and SDA pins
-  for (i = 0; i < TOTAL_PINS; i++) {
-    if (IS_PIN_I2C(i)) {
-      // mark pins as i2c so they are ignore in non i2c data requests
-      setPinModeCallback(i, PIN_MODE_I2C);
-    }
-  }
-
-  isI2CEnabled = true;
-
-  Wire.begin();
-}
-
-/* disable the i2c pins so they can be used for other functions */
-void disableI2CPins() {
-  isI2CEnabled = false;
-  // disable read continuous mode for all devices
-  queryIndex = -1;
 }
 
 /*==============================================================================

--- a/utility/SerialFirmata.cpp
+++ b/utility/SerialFirmata.cpp
@@ -14,17 +14,19 @@
 
   - handlePinMode calls Firmata::setPinMode
 
-  Last updated by Jeff Hoefs: January 10th, 2016
+  Last updated October 16th, 2016
 */
 
 #include "SerialFirmata.h"
 
 SerialFirmata::SerialFirmata()
 {
+#if defined(SoftwareSerial_h)
   swSerial0 = NULL;
   swSerial1 = NULL;
   swSerial2 = NULL;
   swSerial3 = NULL;
+#endif
 
   serialIndex = -1;
 }

--- a/utility/SerialFirmata.h
+++ b/utility/SerialFirmata.h
@@ -15,7 +15,7 @@
   - Defines FIRMATA_SERIAL_FEATURE (could add to Configurable version as well)
   - Imports Firmata.h rather than ConfigurableFirmata.h
 
-  Last updated by Jeff Hoefs: January 10th, 2016
+  Last updated October 16th, 2016
 */
 
 #ifndef SerialFirmata_h
@@ -23,10 +23,10 @@
 
 #include <Firmata.h>
 #include "FirmataFeature.h"
-// SoftwareSerial is currently only supported for AVR-based boards and the Arduino 101
-// The third condition checks if the IDE is in the 1.0.x series, if so, include SoftwareSerial
-// since it should be available to all boards in that IDE.
-#if defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_ARC32) || (ARDUINO >= 100 && ARDUINO < 10500)
+// SoftwareSerial is currently only supported for AVR-based boards and the Arduino 101.
+// Limited to Arduino 1.6.6 or higher because Arduino builder cannot find SoftwareSerial
+// prior to this release.
+#if (ARDUINO > 10605) && (defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_ARC32))
 #include <SoftwareSerial.h>
 #endif
 
@@ -155,10 +155,12 @@ class SerialFirmata: public FirmataFeature
     int serialBytesToRead[SERIAL_READ_ARR_LEN];
     signed char serialIndex;
 
+#if defined(SoftwareSerial_h)
     Stream *swSerial0;
     Stream *swSerial1;
     Stream *swSerial2;
     Stream *swSerial3;
+#endif
 
     Stream* getPortFromId(byte portId);
 


### PR DESCRIPTION
Firmata should now compile without errors back to Arduino IDE version 1.0.6 (for the 1.0.x series) and version 1.5.8 for the (1.5.x / 1.6.x series). I haven't tried on anything older than 1.0.6 or 1.5.8.