### PR TITLE
Update FirmataParser to support older compilers

### DIFF
--- a/FirmataParser.cpp
+++ b/FirmataParser.cpp
@@ -29,7 +29,6 @@ FirmataParser::FirmataParser()
 :
     executeMultiByteCommand(0),
     multiByteChannel(0),
-    storedInputData{0},
     waitForData(0),
     parsingSysex(false),
     sysexBytesRead(0),


### PR DESCRIPTION
Addresses issue #322 

Passes all tests I have available