### PR TITLE
Add FirmataMarshaller::sendCapabilityQuery

### DIFF
--- a/FirmataMarshaller.cpp
+++ b/FirmataMarshaller.cpp
@@ -98,6 +98,17 @@ const
   sendValueAsTwo7bitBytes(value);
 }
 
+/**
+ * Send a capability query to the Firmata host application. The resulting sysex message will have
+ * a CAPABILITY_RESPONSE command byte, followed by a list of byte tuples (mode and mode resolution)
+ * for each pin; where each pin list is terminated by 0x7F (128).
+ */
+void FirmataMarshaller::sendCapabilityQuery(void)
+const
+{
+  sendSysex(CAPABILITY_QUERY, 0, NULL);
+}
+
 /* (intentionally left out asterix here)
  * STUB - NOT IMPLEMENTED
  * Send a single digital pin value to the Firmata host application.

--- a/FirmataMarshaller.h
+++ b/FirmataMarshaller.h
@@ -37,6 +37,7 @@ class FirmataMarshaller
 
     /* serial send handling */
     void sendAnalog(uint8_t pin, uint16_t value) const;
+    void sendCapabilityQuery(void) const;
     void sendDigital(uint8_t pin, uint16_t value) const;
     void sendDigitalPort(uint8_t portNumber, uint16_t portData) const;
     void sendString(const char *string) const;


### PR DESCRIPTION
Beginning to expand the marshalling layer. This does not break backward compatibility or disturb the `Firmata.h` API surface.