### PR TITLE
Abstract FirmataParser memory allocation scheme

### DIFF
--- a/Firmata.cpp
+++ b/Firmata.cpp
@@ -75,6 +75,8 @@ void FirmataClass::endSysex(void)
  * An instance named "Firmata" is created automatically for the user.
  */
 FirmataClass::FirmataClass()
+:
+  parser(FirmataParser(parserBuffer, MAX_DATA_BYTES))
 {
   firmwareVersionCount = 0;
   firmwareVersionVector = 0;

--- a/Firmata.h
+++ b/Firmata.h
@@ -97,6 +97,7 @@ class FirmataClass
     void endSysex(void);
 
   private:
+    uint8_t parserBuffer[MAX_DATA_BYTES];
     FirmataMarshaller marshaller;
     FirmataParser parser;
     Stream *FirmataStream;


### PR DESCRIPTION
This is ready for testing. I haven't had any opportunity to test this between hardware, but it does pass the test suite.

I wanted to share what I'm working on, so I could get feedback. I think it resolves the memory allocation concerns @soundanalogous pointed out in issue #328, and it can also handle my desire to utilize `realloc()`.

I will report back once I've had an opportunity to test.
[EDIT] I have confirmed it works with Windows Remote Arduino.
[EDIT] I have confirmed it works as expected on Linux.