### PR TITLE
Add cast for compatibility with the next version of CurieBLE

### DIFF
--- a/utility/BLEStream.h
+++ b/utility/BLEStream.h
@@ -118,7 +118,7 @@ bool BLEStream::poll()
 
 void BLEStream::end()
 {
-  this->_rxCharacteristic.setEventHandler(BLEWritten, NULL);
+  this->_rxCharacteristic.setEventHandler(BLEWritten, (void(*)(BLECentral&, BLECharacteristic&))NULL);
   this->_rxHead = this->_rxTail = 0;
   flush();
   BLEPeripheral::disconnect();


### PR DESCRIPTION
Arduino and Intel are working on a new API for CurieBLE, progress can be seen here: https://github.com/01org/corelibs-arduino101/pull/337

There's a backwards compatibility layer with the existing BLEPeripheral based API, so for the most part no code changes will be needed for CurieBLE users once they upgrade.

However, we've overloaded `BLECharacteristic::setEventHandler(...)` with the following:

```
typedef void (*BLECharacteristicEventHandler)(BLEDevice bledev, BLECharacteristic characteristic);

typedef void (*BLECharacteristicEventHandlerOld)(BLECentral &central, BLECharacteristic &characteristic);

    void setEventHandler(BLECharacteristicEvent event, 
                         BLECharacteristicEventHandler eventHandler);
    void setEventHandler(BLECharacteristicEvent event, 
                         BLECharacteristicEventHandlerOld eventHandler);
```

So there's a tiny casting change needed in Firmata need for compatibility, only because a `NULL` value is passed into `setEventHandler`. For now we think adding a cast is the best solution to move forward, but are open to other ideas.

cc/ @facchinm @SidLeung @sgbihu @noelpaz @russmcinnis 