### PR TITLE
Added extra analogRead() to let ADC cool off

### DIFF
--- a/examples/StandardFirmata/StandardFirmata.ino
+++ b/examples/StandardFirmata/StandardFirmata.ino
@@ -805,6 +805,8 @@ void loop()
       if (IS_PIN_ANALOG(pin) && Firmata.getPinMode(pin) == PIN_MODE_ANALOG) {
         analogPin = PIN_TO_ANALOG(pin);
         if (analogInputsToReport & (1 << analogPin)) {
+          // Extra analogRead() to cover ADC cooling-off period for higher accuracy
+          analogRead(analogPin);
           Firmata.sendAnalog(analogPin, analogRead(analogPin));
         }
       }


### PR DESCRIPTION
Proposed bug fix for: https://github.com/firmata/arduino/issues/334

**Summary of bug**
Reading multiple analog sensors the same time messes up all readings. For example: the LM35 works fine on its own reporting consistent values but as soon as another analog sensor is added it starts reporting random values between 12 - 50 C°. I tested this with multiple sensors with the same result.

The bug is most likely with the Arduino hardware as I managed to reproduce the issue with a simple two line Arduino sketch.

**Test**
I tested multiple analog sensors and combinations on a Genuine Arduino UNO and had the same issue all the time. I also tested on a Chinese Arduino NANO which had the same problem.

**My proposed solution have fixed issues on both Arduinos**

I only noticed at the end that apparently both Arduinos have an ATMEL MEGA 328P on board so it would be great to test the solution on other chips as well but I don't have access to any other boards at the moment.