### PR TITLE
Initial approach to a Firmata SPI implementation

### DIFF
--- a/examples/StandardFirmataPlus/StandardFirmataPlus.ino
+++ b/examples/StandardFirmataPlus/StandardFirmataPlus.ino
@@ -52,6 +52,8 @@
 // Arduino IDE v1.6.6 or higher. Hardware serial should work back to Arduino 1.0.
 #include "utility/SerialFirmata.h"
 
+#include "utility/SPIFirmata.h"
+
 #define I2C_WRITE                   B00000000
 #define I2C_READ                    B00001000
 #define I2C_READ_CONTINUOUSLY       B00010000
@@ -74,6 +76,10 @@
 
 #ifdef FIRMATA_SERIAL_FEATURE
 SerialFirmata serialFeature;
+#endif
+
+#ifdef FIRMATA_SPI_FEATURE
+SPIFirmata spiFeature;
 #endif
 
 /* analog inputs */
@@ -378,6 +384,11 @@ void setPinModeCallback(byte pin, int mode)
     case PIN_MODE_SERIAL:
 #ifdef FIRMATA_SERIAL_FEATURE
       serialFeature.handlePinMode(pin, PIN_MODE_SERIAL);
+#endif
+      break;
+    case PIN_MODE_SPI:
+#ifdef FIRMATA_SPI_FEATURE
+      spiFeature.handlePinMode(pin, PIN_MODE_SPI);
 #endif
       break;
     default:
@@ -685,6 +696,9 @@ void sysexCallback(byte command, byte argc, byte *argv)
 #ifdef FIRMATA_SERIAL_FEATURE
         serialFeature.handleCapability(pin);
 #endif
+#ifdef FIRMATA_SPI_FEATURE
+        spiFeature.handleCapability(pin);
+#endif
         Firmata.write(127);
       }
       Firmata.write(END_SYSEX);
@@ -718,6 +732,12 @@ void sysexCallback(byte command, byte argc, byte *argv)
       serialFeature.handleSysex(command, argc, argv);
 #endif
       break;
+
+    case SPI_DATA:
+#ifdef FIRMATA_SPI_FEATURE
+      spiFeature.handleSysex(command, argc, argv);
+#endif
+      break;
   }
 }
 
@@ -734,6 +754,10 @@ void systemResetCallback()
 
 #ifdef FIRMATA_SERIAL_FEATURE
   serialFeature.reset();
+#endif
+
+#ifdef FIRMATA_SPI_FEATURE
+  spiFeature.reset();
 #endif
 
   if (isI2CEnabled) {

--- a/utility/SPIFirmata.cpp
+++ b/utility/SPIFirmata.cpp
@@ -1,0 +1,205 @@
+/*
+  SPIFirmata.cpp
+  Copyright (C) 2017 Jeff Hoefs. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  See file LICENSE.txt for further informations on licensing terms.
+
+  Last updated January 3rd, 2017
+*/
+
+#include "SPIFirmata.h"
+
+SPIFirmata::SPIFirmata()
+{
+  mDeviceId = 0;
+  mCsPin = -1;
+}
+
+boolean SPIFirmata::handlePinMode(byte pin, int mode)
+{
+  // ignore SS pin for now
+  if (mode == PIN_MODE_SPI && pin != SS) {
+    Firmata.setPinMode(pin, PIN_MODE_SPI);
+    return true;
+  }
+  return false;
+}
+
+void SPIFirmata::handleCapability(byte pin)
+{
+  // ignore SS pin for now
+  if (IS_PIN_SPI(pin) && pin != SS) {
+    Firmata.write(PIN_MODE_SPI);
+    // would actually use a value that corresponds to a specific pin (MOSI, MISO, SCK)
+    // for now, just set to 1
+    Firmata.write(1);
+  }
+}
+
+boolean SPIFirmata::handleSysex(byte command, byte argc, byte *argv)
+{
+  if (command == SPI_DATA) {
+    byte mode = argv[0];
+    // not using channel yet
+    byte channel = argv[1] & SPI_CHANNEL_MASK;
+
+    switch (mode) {
+      case SPI_CONFIG:
+        SPI.begin();
+        break;
+      case SPI_BEGIN_TRANSACTION:
+      {
+        mDeviceId = argv[1] >> 2;
+        byte bitOrder = argv[2] & SPI_BIT_ORDER_MASK;
+        byte dataMode = argv[2] >> 1;
+        long clockSpeed = (long)argv[3] | ((long)argv[4] << 7) | ((long)argv[5] << 14) |
+                          ((long)argv[6] << 21) | ((long)argv[7] << 28);
+
+        if (argc > 8) {
+          mCsPin = argv[8];
+          pinMode(mCsPin, OUTPUT);
+          // protect the CS pin
+          Firmata.setPinMode(mCsPin, PIN_MODE_SPI);
+        }
+        SPISettings settings(clockSpeed, bitOrder, dataMode);
+        SPI.beginTransaction(settings);
+        break;
+      }
+      case SPI_END_TRANSACTION:
+        SPI.endTransaction();
+        break;
+      case SPI_TRANSFER:
+      {
+        byte transferOptions = argv[2] & SPI_TRANSFER_OPTS_MASK;
+        byte numBytes = argv[3];
+
+        boolean csIsActive = false;
+        byte csStartVal = LOW;
+        byte csEndVal = HIGH;
+        boolean csStartOnly = false;
+        boolean csEndOnly = false;
+
+        //boolean csToggle = false;
+
+        if (mCsPin >= 0) {
+          if (argv[2] & SPI_CS_ACTIVE_MASK) {
+            csIsActive = true;
+            if (argv[2] & SPI_CS_START_ONLY_MASK) csStartOnly = true;
+            if (argv[2] & SPI_CS_END_ONLY_MASK) csEndOnly = true;
+            // TODO - handle csToggle
+            // if (argv[2] & SPI_CS_TOGGLE_MASK) csToggle = true;
+            if (argv[2] & SPI_CS_INVERT_VAL_MASK) {
+              csStartVal = HIGH;
+              csStartVal = LOW;
+            }
+          }
+        }
+
+        if ((csIsActive || csStartOnly) && !csEndOnly) {
+          digitalWrite(mCsPin, csStartVal);
+        }
+
+        if (transferOptions == SPI_READ_WRITE) {
+          readWrite(channel, numBytes, argc, argv);
+        } else if (transferOptions == SPI_READ_ONLY) {
+          readOnly(channel, numBytes);
+        } else if (transferOptions == SPI_WRITE_ONLY) {
+          writeOnly(channel, numBytes, argc, argv);
+        } else {
+          // TODO - handle error
+          Firmata.sendString("No transferOptions set");
+        }
+
+        if ((csIsActive || csEndOnly) && !csStartOnly) {
+          digitalWrite(mCsPin, csEndVal);
+        }
+        break; // SPI_TRANSFER
+      }
+      case SPI_END:
+        SPI.end();
+        break;
+    } // end switch
+    return true;
+  }
+  return false;
+}
+
+void SPIFirmata::reset()
+{
+  mCsPin = -1;
+  mDeviceId = 0;
+}
+
+void SPIFirmata::readWrite(byte channel, byte numBytes, byte argc, byte *argv)
+{
+  Firmata.sendString("readWrite");
+  byte offset = 4; // mode + channel + opts + numBytes
+  if (numBytes * 2 != argc - offset) {
+    // TODO - handle error
+    Firmata.sendString("fails numBytes test");
+  }
+  byte buffer[numBytes];
+  byte bufferIndex = 0;
+  for (byte i = 0; i < numBytes * 2; i += 2) {
+    bufferIndex = (i + 1) / 2;
+    buffer[bufferIndex] = argv[i + offset + 1] << 7 | argv[i + offset];
+  }
+  SPI.transfer(buffer, numBytes);
+
+  reply(channel, numBytes, buffer);
+}
+
+// TODO - eliminate duplication between readWrite and writeOnly
+void SPIFirmata::writeOnly(byte channel, byte numBytes, byte argc, byte *argv)
+{
+  Firmata.sendString("writeOnly");
+  byte offset = 4;
+  if (numBytes * 2 != argc - offset) {
+    // TODO - handle error
+    Firmata.sendString("fails numBytes test");
+  }
+
+  byte buffer[numBytes];
+  byte bufferIndex = 0;
+  for (byte i = 0; i < numBytes * 2; i += 2) {
+    bufferIndex = (i + 1) / 2;
+    buffer[bufferIndex] = argv[i + offset + 1] << 7 | argv[i + offset];
+  }
+  SPI.transfer(buffer, numBytes);
+}
+
+// TODO - combine readWrite and readOnly by sending zero for each byte read
+// in read-only mode.
+// That leaves us with read and writeOnly
+void SPIFirmata::readOnly(byte channel, byte numBytes)
+{
+  Firmata.sendString("readOnly");
+  byte buffer[numBytes];
+  for (byte i = 0; i < numBytes; i++) {
+    buffer[i] = 0;
+  }
+  SPI.transfer(buffer, numBytes);
+
+  reply(channel, numBytes, buffer);
+}
+
+void SPIFirmata::reply(byte channel, byte numBytes, byte *buffer)
+{
+  Firmata.write(START_SYSEX);
+  Firmata.write(SPI_DATA);
+  Firmata.write(SPI_REPLY);
+  Firmata.write(mDeviceId << 2 | channel);
+  Firmata.write(numBytes);
+
+  for (byte i = 0; i < numBytes; i++) {
+    Firmata.write(buffer[i] & 0x7F);
+    Firmata.write(buffer[i] >> 7 & 0x7F);
+  }
+
+  Firmata.write(END_SYSEX);
+}

--- a/utility/SPIFirmata.cpp
+++ b/utility/SPIFirmata.cpp
@@ -9,7 +9,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated January 3rd, 2017
+  Last updated January 7th, 2017
 */
 
 #include "SPIFirmata.h"
@@ -64,6 +64,8 @@ boolean SPIFirmata::handleSysex(byte command, byte argc, byte *argv)
           mCsPin = argv[8];
           pinMode(mCsPin, OUTPUT);
           // protect the CS pin
+          // TODO - decide if this is the best approach. If PIN_MODE_SPI is set, the user cannot
+          // manually control the CS pin using DIGITAL_MESSAGE.
           Firmata.setPinMode(mCsPin, PIN_MODE_SPI);
         }
         SPISettings settings(clockSpeed, getBitOrder(bitOrder), getDataMode(dataMode));
@@ -78,7 +80,7 @@ boolean SPIFirmata::handleSysex(byte command, byte argc, byte *argv)
         byte transferOptions = argv[2] & SPI_TRANSFER_OPTS_MASK;
         byte numBytes = argv[3];
 
-        boolean csIsActive = false;
+        boolean csIsActive = true;
         byte csStartVal = LOW;
         byte csEndVal = HIGH;
         boolean csStartOnly = false;
@@ -87,16 +89,17 @@ boolean SPIFirmata::handleSysex(byte command, byte argc, byte *argv)
         //boolean csToggle = false;
 
         if (mCsPin >= 0) {
-          if (argv[2] & SPI_CS_ACTIVE_MASK) {
-            csIsActive = true;
+          if (argv[2] & SPI_CS_DISABLE_MASK) {
+            csIsActive = false;
+          } else {
             if (argv[2] & SPI_CS_START_ONLY_MASK) csStartOnly = true;
             if (argv[2] & SPI_CS_END_ONLY_MASK) csEndOnly = true;
-            // TODO - handle csToggle
-            // if (argv[2] & SPI_CS_TOGGLE_MASK) csToggle = true;
-            if (argv[2] & SPI_CS_INVERT_VAL_MASK) {
+            if (argv[2] & SPI_CS_ACTIVE_EDGE_MASK) {
               csStartVal = HIGH;
               csStartVal = LOW;
             }
+            // TODO - handle csToggle
+            // if (argv[2] & SPI_CS_TOGGLE_MASK) csToggle = true;
           }
         }
 

--- a/utility/SPIFirmata.h
+++ b/utility/SPIFirmata.h
@@ -1,0 +1,74 @@
+/*
+  SPIFirmata.h
+  Copyright (C) 2017 Jeff Hoefs. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  See file LICENSE.txt for further informations on licensing terms.
+
+  Last updated January 3rd, 2017
+*/
+
+#ifndef SPIFirmata_h
+#define SPIFirmata_h
+
+#include <Firmata.h>
+#include "FirmataFeature.h"
+#include <SPI.h>
+
+#define FIRMATA_SPI_FEATURE
+
+// following 2 defines belong in FirmataConstants.h, but declaring them here
+// since this implementation is still a prototype
+#define SPI_DATA                    0x68
+#define PIN_MODE_SPI                0x0C
+
+// SPI mode bytes
+#define SPI_CONFIG                  0x00
+#define SPI_BEGIN_TRANSACTION       0x01
+#define SPI_END_TRANSACTION         0x02
+#define SPI_TRANSFER                0x03
+#define SPI_REPLY                   0x04
+#define SPI_END                     0x05
+
+// transfer options
+#define SPI_TRANSFER_OPTS_MASK      0x03
+#define SPI_READ_WRITE              0x00
+#define SPI_READ_ONLY               0x01
+#define SPI_WRITE_ONLY              0x02
+
+// pinOptions
+#define SPI_CS_ACTIVE_MASK          0x04
+#define SPI_CS_INVERT_VAL_MASK      0x08
+#define SPI_CS_START_ONLY_MASK      0x10
+#define SPI_CS_END_ONLY_MASK        0x20
+#define SPI_CS_TOGGLE_MASK          0x40
+
+#define SPI_CHANNEL_MASK            0x03
+#define SPI_DEVICE_ID_MASK          0x7C
+#define SPI_BIT_ORDER_MASK          0x01
+
+
+class SPIFirmata: public FirmataFeature
+{
+  public:
+    SPIFirmata();
+    boolean handlePinMode(byte pin, int mode);
+    void handleCapability(byte pin);
+    boolean handleSysex(byte command, byte argc, byte *argv);
+    void reset();
+
+  private:
+    signed char mCsPin;
+    byte mDeviceId;
+
+    void readWrite(byte channel, byte numBytes, byte argc, byte *argv);
+    void readOnly(byte channel, byte numBytes);
+    void writeOnly(byte channel, byte numBytes, byte argc, byte *argv);
+    void reply(byte channel, byte numBytes, byte *buffer);
+};
+
+#endif /* SPIFirmata_h */

--- a/utility/SPIFirmata.h
+++ b/utility/SPIFirmata.h
@@ -9,7 +9,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated January 3rd, 2017
+  Last updated January 7th, 2017
 */
 
 #ifndef SPIFirmata_h
@@ -41,10 +41,10 @@
 #define SPI_WRITE_ONLY              0x02
 
 // pinOptions
-#define SPI_CS_ACTIVE_MASK          0x04
-#define SPI_CS_INVERT_VAL_MASK      0x08
-#define SPI_CS_START_ONLY_MASK      0x10
-#define SPI_CS_END_ONLY_MASK        0x20
+#define SPI_CS_DISABLE_MASK         0x04
+#define SPI_CS_START_ONLY_MASK      0x08
+#define SPI_CS_END_ONLY_MASK        0x10
+#define SPI_CS_ACTIVE_EDGE_MASK     0x20
 #define SPI_CS_TOGGLE_MASK          0x40
 
 #define SPI_CHANNEL_MASK            0x03

--- a/utility/SPIFirmata.h
+++ b/utility/SPIFirmata.h
@@ -51,6 +51,32 @@
 #define SPI_DEVICE_ID_MASK          0x7C
 #define SPI_BIT_ORDER_MASK          0x01
 
+namespace {
+// TODO - check Teensy and other non SAM, SAMD or AVR variants
+#if defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_SAM)
+  inline BitOrder getBitOrder(uint8_t value) {
+    if (value == 0) return LSBFIRST;
+    return MSBFIRST; // default
+  }
+#else
+  inline uint8_t getBitOrder(uint8_t value) {
+    if (value == 0) return LSBFIRST;
+    return MSBFIRST; // default
+  }
+#endif
+
+  inline uint8_t getDataMode(uint8_t value) {
+    if (value == 1) {
+      return SPI_MODE1;
+    } else if (value == 2) {
+      return SPI_MODE2;
+    } else if (value == 3) {
+      return SPI_MODE3;
+    }
+    return SPI_MODE0; // default
+  }
+
+}
 
 class SPIFirmata: public FirmataFeature
 {


### PR DESCRIPTION
This is an initial approach to Firmata SPI support. Consider this a prototype for now. The draft proposal that this implementation is based on is available here: https://github.com/firmata/protocol/blob/spi/spi-proposal.md. Also see comments in the proposal here for an overview on potential changes: https://github.com/firmata/protocol/pull/27/files.

SPI is a difficult protocol to implement in a generic way. The idea with this prototype implementation is to get it out there and have people start testing with various SPI devices to see where it falls short.

A prototype Firmata client implementation is also being explored for firmata.js: https://github.com/firmata/firmata.js/compare/spi-alpha. You can use that to test devices or use it as an example for testing in other programming environments.

Note that both the Arduino implementation and the firmata.js are still changing, but should be stable enough to checkout and test with (just be sure to checkout both at the same time as I'm pushing updates simultaneously).


