### PR TITLE
Support analog (and motor) control on the ESP8266

### DIFF
--- a/examples/StandardFirmataWiFi/StandardFirmataWiFi.ino
+++ b/examples/StandardFirmataWiFi/StandardFirmataWiFi.ino
@@ -995,6 +995,9 @@ void initFirmata()
 void setup()
 {
   DEBUG_BEGIN(9600);
+#ifdef ESP8266
+  analogWriteRange(255);
+#endif
 
   initTransport();
 


### PR DESCRIPTION
The ESP8266 doesn't play friendly with firmata or Johnny-Five because, in its default configuration, it expects PWM inputs to be in [0..1023] instead of [0..255].

The attached PR implements the simplest possible solution as a stopgap until a better solution can be found to resolve the general case for chips of varying resolutions.