### PR TITLE
Core

### DIFF
--- a/FirmataMarshaller.cpp
+++ b/FirmataMarshaller.cpp
@@ -98,6 +98,17 @@ const
   sendValueAsTwo7bitBytes(value);
 }
 
+/**
+ * Send a capability query to the Firmata host application. The resulting sysex message will have
+ * a CAPABILITY_RESPONSE command byte, followed by a list of byte tuples (mode and mode resolution)
+ * for each pin; where each pin list is terminated by 0x7F (128).
+ */
+void FirmataMarshaller::sendCapabilityQuery(void)
+const
+{
+  sendSysex(CAPABILITY_QUERY, 0, NULL);
+}
+
 /* (intentionally left out asterix here)
  * STUB - NOT IMPLEMENTED
  * Send a single digital pin value to the Firmata host application.

--- a/FirmataMarshaller.cpp
+++ b/FirmataMarshaller.cpp
@@ -124,7 +124,7 @@ void FirmataMarshaller::end(void)
 void FirmataMarshaller::reportAnalogDisable(uint8_t pin)
 const
 {
-    reportAnalog(pin, false);
+  reportAnalog(pin, false);
 }
 
 /**
@@ -133,13 +133,11 @@ const
  * (16384). To increase the pin range or value, see the documentation for the EXTENDED_ANALOG
  * message.
  * @param pin The analog pin for which to request the value (limited to pins 0 - 15).
- * @param stream_enable A zero value will disable the stream, a non-zero will enable the stream
- * @note The maximum resulting value is 14-bits (16384).
  */
 void FirmataMarshaller::reportAnalogEnable(uint8_t pin)
 const
 {
-    reportAnalog(pin, true);
+  reportAnalog(pin, true);
 }
 
 /**
@@ -148,12 +146,11 @@ const
  * @param portNumber The port number for which to request the value. Note that this is not the same as a "port" on the
  * physical microcontroller. Ports are defined in order per every 8 pins in ascending order
  * of the Arduino digital pin numbering scheme. Port 0 = pins D0 - D7, port 1 = pins D8 - D15, etc.
- * @param stream_enable A zero value will disable the stream, a non-zero will enable the stream
  */
 void FirmataMarshaller::reportDigitalPortDisable(uint8_t portNumber)
 const
 {
-    reportDigitalPort(portNumber, false);
+  reportDigitalPort(portNumber, false);
 }
 
 /**
@@ -162,12 +159,11 @@ const
  * @param portNumber The port number for which to request the value. Note that this is not the same as a "port" on the
  * physical microcontroller. Ports are defined in order per every 8 pins in ascending order
  * of the Arduino digital pin numbering scheme. Port 0 = pins D0 - D7, port 1 = pins D8 - D15, etc.
- * @param stream_enable A zero value will disable the stream, a non-zero will enable the stream
  */
 void FirmataMarshaller::reportDigitalPortEnable(uint8_t portNumber)
 const
 {
-    reportDigitalPort(portNumber, true);
+  reportDigitalPort(portNumber, true);
 }
 
 /**
@@ -189,9 +185,20 @@ const
 }
 
 /**
+ * Send an analog mapping query to the Firmata host application. The resulting sysex message will
+ * have an ANALOG_MAPPING_RESPONSE command byte, followed by a list of pins [0-n]; where each
+ * pin will specify its corresponding analog pin number or 0x7F (127) if not applicable.
+ */
+void FirmataMarshaller::sendAnalogMappingQuery(void)
+const
+{
+  sendSysex(ANALOG_MAPPING_QUERY, 0, NULL);
+}
+
+/**
  * Send a capability query to the Firmata host application. The resulting sysex message will have
  * a CAPABILITY_RESPONSE command byte, followed by a list of byte tuples (mode and mode resolution)
- * for each pin; where each pin list is terminated by 0x7F (128).
+ * for each pin; where each pin list is terminated by 0x7F (127).
  */
 void FirmataMarshaller::sendCapabilityQuery(void)
 const

--- a/FirmataMarshaller.h
+++ b/FirmataMarshaller.h
@@ -41,6 +41,7 @@ class FirmataMarshaller
     void reportDigitalPortDisable(uint8_t portNumber) const;
     void reportDigitalPortEnable(uint8_t portNumber) const;
     void sendAnalog(uint8_t pin, uint16_t value) const;
+    void sendAnalogMappingQuery(void) const;
     void sendCapabilityQuery(void) const;
     void sendDigital(uint8_t pin, uint8_t value) const;
     void sendDigitalPort(uint8_t portNumber, uint16_t portData) const;

--- a/FirmataMarshaller.h
+++ b/FirmataMarshaller.h
@@ -36,18 +36,25 @@ class FirmataMarshaller
     void end();
 
     /* serial send handling */
+    void reportAnalogDisable(uint8_t pin) const;
+    void reportAnalogEnable(uint8_t pin) const;
+    void reportDigitalPortDisable(uint8_t portNumber) const;
+    void reportDigitalPortEnable(uint8_t portNumber) const;
     void sendAnalog(uint8_t pin, uint16_t value) const;
     void sendCapabilityQuery(void) const;
-    void sendDigital(uint8_t pin, uint16_t value) const;
+    void sendDigital(uint8_t pin, uint8_t value) const;
     void sendDigitalPort(uint8_t portNumber, uint16_t portData) const;
+    void sendPinMode(uint8_t pin, uint8_t config) const;
     void sendString(const char *string) const;
     void sendSysex(uint8_t command, size_t bytec, uint8_t *bytev) const;
 
   private:
     /* utility methods */
+    void reportAnalog(uint8_t pin, bool stream_enable) const;
+    void reportDigitalPort(uint8_t portNumber, bool stream_enable) const;
     void sendValueAsTwo7bitBytes(uint16_t value) const;
 
-    Stream *FirmataStream;
+    Stream * FirmataStream;
 };
 
 #endif /* FirmataMarshaller_h */

--- a/FirmataMarshaller.h
+++ b/FirmataMarshaller.h
@@ -37,6 +37,7 @@ class FirmataMarshaller
 
     /* serial send handling */
     void sendAnalog(uint8_t pin, uint16_t value) const;
+    void sendCapabilityQuery(void) const;
     void sendDigital(uint8_t pin, uint16_t value) const;
     void sendDigitalPort(uint8_t portNumber, uint16_t portData) const;
     void sendString(const char *string) const;

--- a/FirmataParser.cpp
+++ b/FirmataParser.cpp
@@ -98,7 +98,7 @@ void FirmataParser::parse(uint8_t inputData)
       switch (executeMultiByteCommand) {
         case ANALOG_MESSAGE:
           if (currentAnalogCallback) {
-            (*currentAnalogCallback)(this,
+            (*currentAnalogCallback)(currentAnalogCallbackContext,
                                      multiByteChannel,
                                      (dataBuffer[0] << 7)
                                      + dataBuffer[1]);
@@ -106,7 +106,7 @@ void FirmataParser::parse(uint8_t inputData)
           break;
         case DIGITAL_MESSAGE:
           if (currentDigitalCallback) {
-            (*currentDigitalCallback)(this,
+            (*currentDigitalCallback)(currentDigitalCallbackContext,
                                       multiByteChannel,
                                       (dataBuffer[0] << 7)
                                       + dataBuffer[1]);
@@ -114,19 +114,19 @@ void FirmataParser::parse(uint8_t inputData)
           break;
         case SET_PIN_MODE:
           if (currentPinModeCallback)
-            (*currentPinModeCallback)(this, dataBuffer[1], dataBuffer[0]);
+            (*currentPinModeCallback)(currentPinModeCallbackContext, dataBuffer[1], dataBuffer[0]);
           break;
         case SET_DIGITAL_PIN_VALUE:
           if (currentPinValueCallback)
-            (*currentPinValueCallback)(this, dataBuffer[1], dataBuffer[0]);
+            (*currentPinValueCallback)(currentPinValueCallbackContext, dataBuffer[1], dataBuffer[0]);
           break;
         case REPORT_ANALOG:
           if (currentReportAnalogCallback)
-            (*currentReportAnalogCallback)(this, multiByteChannel, dataBuffer[0]);
+            (*currentReportAnalogCallback)(currentReportAnalogCallbackContext, multiByteChannel, dataBuffer[0]);
           break;
         case REPORT_DIGITAL:
           if (currentReportDigitalCallback)
-            (*currentReportDigitalCallback)(this, multiByteChannel, dataBuffer[0]);
+            (*currentReportDigitalCallback)(currentReportDigitalCallbackContext, multiByteChannel, dataBuffer[0]);
           break;
       }
       executeMultiByteCommand = 0;
@@ -162,7 +162,7 @@ void FirmataParser::parse(uint8_t inputData)
         break;
       case REPORT_VERSION:
         if (currentReportVersionCallback)
-          (*currentReportVersionCallback)(this);
+          (*currentReportVersionCallback)(currentReportVersionCallbackContext);
         break;
     }
   }
@@ -207,7 +207,9 @@ int FirmataParser::setDataBufferOfSize(uint8_t * dataBuffer, size_t dataBufferSi
  * DIGITAL_MESSAGE, REPORT_ANALOG, REPORT DIGITAL, SET_PIN_MODE and SET_DIGITAL_PIN_VALUE).
  * @param command The ID of the command to attach a callback function to.
  * @param newFunction A reference to the callback function to attach.
- * @param context The context for the callback function.
+ * @param context An optional context to be provided to the callback function (NULL by default).
+ * @note The context parameter is provided so you can pass a parameter, by reference, to
+ *       your callback function.
  */
 void FirmataParser::attach(uint8_t command, callbackFunction newFunction, void * context)
 {
@@ -244,7 +246,9 @@ void FirmataParser::attach(uint8_t command, callbackFunction newFunction, void *
  * and SYSTEM_RESET).
  * @param command The ID of the command to attach a callback function to.
  * @param newFunction A reference to the callback function to attach.
- * @param context The context for the callback function.
+ * @param context An optional context to be provided to the callback function (NULL by default).
+ * @note The context parameter is provided so you can pass a parameter, by reference, to
+ *       your callback function.
  */
 void FirmataParser::attach(uint8_t command, systemCallbackFunction newFunction, void * context)
 {
@@ -268,7 +272,9 @@ void FirmataParser::attach(uint8_t command, systemCallbackFunction newFunction, 
  * Attach a callback function for the STRING_DATA command.
  * @param command Must be set to STRING_DATA or it will be ignored.
  * @param newFunction A reference to the string callback function to attach.
- * @param context The context for the callback function.
+ * @param context An optional context to be provided to the callback function (NULL by default).
+ * @note The context parameter is provided so you can pass a parameter, by reference, to
+ *       your callback function.
  */
 void FirmataParser::attach(uint8_t command, stringCallbackFunction newFunction, void * context)
 {
@@ -284,7 +290,9 @@ void FirmataParser::attach(uint8_t command, stringCallbackFunction newFunction, 
  * Attach a generic sysex callback function to sysex command.
  * @param command The ID of the command to attach a callback function to.
  * @param newFunction A reference to the sysex callback function to attach.
- * @param context The context for the callback function.
+ * @param context An optional context to be provided to the callback function (NULL by default).
+ * @note The context parameter is provided so you can pass a parameter, by reference, to
+ *       your callback function.
  */
 void FirmataParser::attach(uint8_t command, sysexCallbackFunction newFunction, void * context)
 {
@@ -296,7 +304,9 @@ void FirmataParser::attach(uint8_t command, sysexCallbackFunction newFunction, v
 /**
  * Attach a buffer overflow callback
  * @param newFunction A reference to the buffer overflow callback function to attach.
- * @param context The context supplied by the end-user, and provided during the execution of the callback
+ * @param context An optional context to be provided to the callback function (NULL by default).
+ * @note The context parameter is provided so you can pass a parameter, by reference, to
+ *       your callback function.
  */
 void FirmataParser::attach(dataBufferOverflowCallbackFunction newFunction, void * context)
 {
@@ -383,7 +393,7 @@ void FirmataParser::processSysexMessage(void)
   switch (dataBuffer[0]) { //first byte in buffer is command
     case REPORT_FIRMWARE:
       if (currentReportFirmwareCallback)
-        (*currentReportFirmwareCallback)(this);
+        (*currentReportFirmwareCallback)(currentReportFirmwareCallbackContext);
       break;
     case STRING_DATA:
       if (currentStringCallback) {
@@ -405,12 +415,12 @@ void FirmataParser::processSysexMessage(void)
         if (dataBuffer[j - 1] != '\0') {
           bufferDataAtPosition('\0', j);
         }
-        (*currentStringCallback)(this, (char *)&dataBuffer[0]);
+        (*currentStringCallback)(currentStringCallbackContext, (char *)&dataBuffer[0]);
       }
       break;
     default:
       if (currentSysexCallback)
-        (*currentSysexCallback)(this, dataBuffer[0], sysexBytesRead - 1, dataBuffer + 1);
+        (*currentSysexCallback)(currentSysexCallbackContext, dataBuffer[0], sysexBytesRead - 1, dataBuffer + 1);
   }
 }
 
@@ -434,5 +444,5 @@ void FirmataParser::systemReset(void)
   sysexBytesRead = 0;
 
   if (currentSystemResetCallback)
-    (*currentSystemResetCallback)(this);
+    (*currentSystemResetCallback)(currentSystemResetCallbackContext);
 }

--- a/FirmataParser.cpp
+++ b/FirmataParser.cpp
@@ -37,19 +37,30 @@ FirmataParser::FirmataParser(uint8_t * const dataBuffer, size_t dataBufferSize)
   waitForData(0),
   parsingSysex(false),
   sysexBytesRead(0),
+  currentAnalogCallbackContext((void *)NULL),
+  currentDigitalCallbackContext((void *)NULL),
+  currentReportAnalogCallbackContext((void *)NULL),
+  currentReportDigitalCallbackContext((void *)NULL),
+  currentPinModeCallbackContext((void *)NULL),
+  currentPinValueCallbackContext((void *)NULL),
+  currentReportFirmwareCallbackContext((void *)NULL),
+  currentReportVersionCallbackContext((void *)NULL),
   currentDataBufferOverflowCallbackContext((void *)NULL),
+  currentStringCallbackContext((void *)NULL),
+  currentSysexCallbackContext((void *)NULL),
+  currentSystemResetCallbackContext((void *)NULL),
   currentAnalogCallback((callbackFunction)NULL),
   currentDigitalCallback((callbackFunction)NULL),
   currentReportAnalogCallback((callbackFunction)NULL),
   currentReportDigitalCallback((callbackFunction)NULL),
   currentPinModeCallback((callbackFunction)NULL),
   currentPinValueCallback((callbackFunction)NULL),
-  currentReportFirmwareCallback((systemCallbackFunction)NULL),
-  currentReportVersionCallback((systemCallbackFunction)NULL),
-  currentSystemResetCallback((systemCallbackFunction)NULL),
+  currentDataBufferOverflowCallback((dataBufferOverflowCallbackFunction)NULL),
   currentStringCallback((stringCallbackFunction)NULL),
   currentSysexCallback((sysexCallbackFunction)NULL),
-  currentDataBufferOverflowCallback((dataBufferOverflowCallbackFunction)NULL)
+  currentReportFirmwareCallback((systemCallbackFunction)NULL),
+  currentReportVersionCallback((systemCallbackFunction)NULL),
+  currentSystemResetCallback((systemCallbackFunction)NULL)
 {
     allowBufferUpdate = ((uint8_t *)NULL == dataBuffer);
 }
@@ -87,33 +98,35 @@ void FirmataParser::parse(uint8_t inputData)
       switch (executeMultiByteCommand) {
         case ANALOG_MESSAGE:
           if (currentAnalogCallback) {
-            (*currentAnalogCallback)(multiByteChannel,
+            (*currentAnalogCallback)(this,
+                                     multiByteChannel,
                                      (dataBuffer[0] << 7)
                                      + dataBuffer[1]);
           }
           break;
         case DIGITAL_MESSAGE:
           if (currentDigitalCallback) {
-            (*currentDigitalCallback)(multiByteChannel,
+            (*currentDigitalCallback)(this,
+                                      multiByteChannel,
                                       (dataBuffer[0] << 7)
                                       + dataBuffer[1]);
           }
           break;
         case SET_PIN_MODE:
           if (currentPinModeCallback)
-            (*currentPinModeCallback)(dataBuffer[1], dataBuffer[0]);
+            (*currentPinModeCallback)(this, dataBuffer[1], dataBuffer[0]);
           break;
         case SET_DIGITAL_PIN_VALUE:
           if (currentPinValueCallback)
-            (*currentPinValueCallback)(dataBuffer[1], dataBuffer[0]);
+            (*currentPinValueCallback)(this, dataBuffer[1], dataBuffer[0]);
           break;
         case REPORT_ANALOG:
           if (currentReportAnalogCallback)
-            (*currentReportAnalogCallback)(multiByteChannel, dataBuffer[0]);
+            (*currentReportAnalogCallback)(this, multiByteChannel, dataBuffer[0]);
           break;
         case REPORT_DIGITAL:
           if (currentReportDigitalCallback)
-            (*currentReportDigitalCallback)(multiByteChannel, dataBuffer[0]);
+            (*currentReportDigitalCallback)(this, multiByteChannel, dataBuffer[0]);
           break;
       }
       executeMultiByteCommand = 0;
@@ -149,7 +162,7 @@ void FirmataParser::parse(uint8_t inputData)
         break;
       case REPORT_VERSION:
         if (currentReportVersionCallback)
-          (*currentReportVersionCallback)();
+          (*currentReportVersionCallback)(this);
         break;
     }
   }
@@ -194,16 +207,35 @@ int FirmataParser::setDataBufferOfSize(uint8_t * dataBuffer, size_t dataBufferSi
  * DIGITAL_MESSAGE, REPORT_ANALOG, REPORT DIGITAL, SET_PIN_MODE and SET_DIGITAL_PIN_VALUE).
  * @param command The ID of the command to attach a callback function to.
  * @param newFunction A reference to the callback function to attach.
+ * @param context The context for the callback function.
  */
-void FirmataParser::attach(uint8_t command, callbackFunction newFunction)
+void FirmataParser::attach(uint8_t command, callbackFunction newFunction, void * context)
 {
   switch (command) {
-    case ANALOG_MESSAGE: currentAnalogCallback = newFunction; break;
-    case DIGITAL_MESSAGE: currentDigitalCallback = newFunction; break;
-    case REPORT_ANALOG: currentReportAnalogCallback = newFunction; break;
-    case REPORT_DIGITAL: currentReportDigitalCallback = newFunction; break;
-    case SET_PIN_MODE: currentPinModeCallback = newFunction; break;
-    case SET_DIGITAL_PIN_VALUE: currentPinValueCallback = newFunction; break;
+    case ANALOG_MESSAGE:
+      currentAnalogCallback = newFunction;
+      currentAnalogCallbackContext = context;
+      break;
+    case DIGITAL_MESSAGE:
+      currentDigitalCallback = newFunction;
+      currentDigitalCallbackContext = context;
+      break;
+    case REPORT_ANALOG:
+      currentReportAnalogCallback = newFunction;
+      currentReportAnalogCallbackContext = context;
+      break;
+    case REPORT_DIGITAL:
+      currentReportDigitalCallback = newFunction;
+      currentReportDigitalCallbackContext = context;
+      break;
+    case SET_PIN_MODE:
+      currentPinModeCallback = newFunction;
+      currentPinModeCallbackContext = context;
+      break;
+    case SET_DIGITAL_PIN_VALUE:
+      currentPinValueCallback = newFunction;
+      currentPinValueCallbackContext = context;
+      break;
   }
 }
 
@@ -212,13 +244,23 @@ void FirmataParser::attach(uint8_t command, callbackFunction newFunction)
  * and SYSTEM_RESET).
  * @param command The ID of the command to attach a callback function to.
  * @param newFunction A reference to the callback function to attach.
+ * @param context The context for the callback function.
  */
-void FirmataParser::attach(uint8_t command, systemCallbackFunction newFunction)
+void FirmataParser::attach(uint8_t command, systemCallbackFunction newFunction, void * context)
 {
   switch (command) {
-    case REPORT_FIRMWARE: currentReportFirmwareCallback = newFunction; break;
-    case REPORT_VERSION: currentReportVersionCallback = newFunction; break;
-    case SYSTEM_RESET: currentSystemResetCallback = newFunction; break;
+    case REPORT_FIRMWARE:
+      currentReportFirmwareCallback = newFunction;
+      currentReportFirmwareCallbackContext = context;
+      break;
+    case REPORT_VERSION:
+      currentReportVersionCallback = newFunction;
+      currentReportVersionCallbackContext = context;
+      break;
+    case SYSTEM_RESET:
+      currentSystemResetCallback = newFunction;
+      currentSystemResetCallbackContext = context;
+      break;
   }
 }
 
@@ -226,11 +268,15 @@ void FirmataParser::attach(uint8_t command, systemCallbackFunction newFunction)
  * Attach a callback function for the STRING_DATA command.
  * @param command Must be set to STRING_DATA or it will be ignored.
  * @param newFunction A reference to the string callback function to attach.
+ * @param context The context for the callback function.
  */
-void FirmataParser::attach(uint8_t command, stringCallbackFunction newFunction)
+void FirmataParser::attach(uint8_t command, stringCallbackFunction newFunction, void * context)
 {
   switch (command) {
-    case STRING_DATA: currentStringCallback = newFunction; break;
+    case STRING_DATA:
+      currentStringCallback = newFunction;
+      currentStringCallbackContext = context;
+      break;
   }
 }
 
@@ -238,11 +284,13 @@ void FirmataParser::attach(uint8_t command, stringCallbackFunction newFunction)
  * Attach a generic sysex callback function to sysex command.
  * @param command The ID of the command to attach a callback function to.
  * @param newFunction A reference to the sysex callback function to attach.
+ * @param context The context for the callback function.
  */
-void FirmataParser::attach(uint8_t command, sysexCallbackFunction newFunction)
+void FirmataParser::attach(uint8_t command, sysexCallbackFunction newFunction, void * context)
 {
   (void)command;
   currentSysexCallback = newFunction;
+  currentSysexCallbackContext = context;
 }
 
 /**
@@ -267,12 +315,17 @@ void FirmataParser::detach(uint8_t command)
     case REPORT_FIRMWARE:
     case REPORT_VERSION:
     case SYSTEM_RESET:
-      attach(command, (systemCallbackFunction)NULL);
+      attach(command, (systemCallbackFunction)NULL, NULL);
       break;
-    case STRING_DATA: currentStringCallback = (stringCallbackFunction)NULL; break;
-    case START_SYSEX: currentSysexCallback = (sysexCallbackFunction)NULL; break;
+    case STRING_DATA:
+      attach(command, (stringCallbackFunction)NULL, NULL);
+      break;
+    case START_SYSEX:
+      attach(command, (sysexCallbackFunction)NULL, NULL);
+      break;
     default:
-      attach(command, (callbackFunction)NULL);
+      attach(command, (callbackFunction)NULL, NULL);
+      break;
   }
 }
 
@@ -330,7 +383,7 @@ void FirmataParser::processSysexMessage(void)
   switch (dataBuffer[0]) { //first byte in buffer is command
     case REPORT_FIRMWARE:
       if (currentReportFirmwareCallback)
-        (*currentReportFirmwareCallback)();
+        (*currentReportFirmwareCallback)(this);
       break;
     case STRING_DATA:
       if (currentStringCallback) {
@@ -352,12 +405,12 @@ void FirmataParser::processSysexMessage(void)
         if (dataBuffer[j - 1] != '\0') {
           bufferDataAtPosition('\0', j);
         }
-        (*currentStringCallback)((char *)&dataBuffer[0]);
+        (*currentStringCallback)(this, (char *)&dataBuffer[0]);
       }
       break;
     default:
       if (currentSysexCallback)
-        (*currentSysexCallback)(dataBuffer[0], sysexBytesRead - 1, dataBuffer + 1);
+        (*currentSysexCallback)(this, dataBuffer[0], sysexBytesRead - 1, dataBuffer + 1);
   }
 }
 
@@ -381,5 +434,5 @@ void FirmataParser::systemReset(void)
   sysexBytesRead = 0;
 
   if (currentSystemResetCallback)
-    (*currentSystemResetCallback)();
+    (*currentSystemResetCallback)(this);
 }

--- a/FirmataParser.h
+++ b/FirmataParser.h
@@ -40,11 +40,11 @@ class FirmataParser
     int setDataBufferOfSize(uint8_t * dataBuffer, size_t dataBufferSize);
 
     /* attach & detach callback functions to messages */
-    void attach(uint8_t command, callbackFunction newFunction, void * context);
-    void attach(dataBufferOverflowCallbackFunction newFunction, void * context);
-    void attach(uint8_t command, stringCallbackFunction newFunction, void * context);
-    void attach(uint8_t command, sysexCallbackFunction newFunction, void * context);
-    void attach(uint8_t command, systemCallbackFunction newFunction, void * context);
+    void attach(uint8_t command, callbackFunction newFunction, void * context = NULL);
+    void attach(dataBufferOverflowCallbackFunction newFunction, void * context = NULL);
+    void attach(uint8_t command, stringCallbackFunction newFunction, void * context = NULL);
+    void attach(uint8_t command, sysexCallbackFunction newFunction, void * context = NULL);
+    void attach(uint8_t command, systemCallbackFunction newFunction, void * context = NULL);
     void detach(uint8_t command);
     void detach(dataBufferOverflowCallbackFunction);
 


### PR DESCRIPTION
This implements the core functionality of Firmata (https://github.com/firmata/protocol/blob/master/protocol.md#message-types) in FirmataMarshaller. It also provides full blown contextual callbacks in the FirmataParser. It does not disrupt the original FirmataClass API.

Provides a stop gap for issues #318, #320, #321

Also accidently contains PR #330 (I believe it will automatically close that PR if accepted).

I have checked to see that it compiles for all the flavors I have in my IDE. It fails for the robot and then NG citing space as the issue. It passes your test cases and I've confirmed it works using the Windows Remote Arduino Experience app in the Windows app store.

I would love a code review, and can you please run your battery of tests once you have a chance?