### PR TITLE
firmware callbacks

### DIFF
--- a/Firmata.cpp
+++ b/Firmata.cpp
@@ -94,7 +94,7 @@ FirmataClass::FirmataClass()
   parser.attach(SET_DIGITAL_PIN_VALUE, (FirmataParser::callbackFunction)staticPinValueCallback, (void *)NULL);
   parser.attach(STRING_DATA, (FirmataParser::stringCallbackFunction)staticStringCallback, (void *)NULL);
   parser.attach(START_SYSEX, (FirmataParser::sysexCallbackFunction)staticSysexCallback, (void *)NULL);
-  parser.attach(REPORT_FIRMWARE, (FirmataParser::systemCallbackFunction)staticReportFirmwareCallback, this);
+  parser.attach(REPORT_FIRMWARE, (FirmataParser::versionCallbackFunction)staticReportFirmwareCallback, this);
   parser.attach(REPORT_VERSION, (FirmataParser::systemCallbackFunction)staticReportVersionCallback, this);
   parser.attach(SYSTEM_RESET, (FirmataParser::systemCallbackFunction)staticSystemResetCallback, (void *)NULL);
 }

--- a/Firmata.h
+++ b/Firmata.h
@@ -148,9 +148,9 @@ class FirmataClass
     inline static void staticPinValueCallback (void *, uint8_t command, uint16_t value) { if ( currentPinValueCallback ) { currentPinValueCallback(command, (int)value); } }
     inline static void staticReportAnalogCallback (void *, uint8_t command, uint16_t value) { if ( currentReportAnalogCallback ) { currentReportAnalogCallback(command, (int)value); } }
     inline static void staticReportDigitalCallback (void *, uint8_t command, uint16_t value) { if ( currentReportDigitalCallback ) { currentReportDigitalCallback(command, (int)value); } }
-    inline static void staticStringCallback (void *, char * c_str) { if ( currentStringCallback ) { currentStringCallback(c_str); } }
+    inline static void staticStringCallback (void *, const char * c_str) { if ( currentStringCallback ) { currentStringCallback((char *)c_str); } }
     inline static void staticSysexCallback (void *, uint8_t command, size_t argc, uint8_t *argv) { if ( currentSysexCallback ) { currentSysexCallback(command, (uint8_t)argc, argv); } }
-    inline static void staticReportFirmwareCallback (void * context) { if ( context ) { ((FirmataClass *)context)->printFirmwareVersion(); } }
+    inline static void staticReportFirmwareCallback (void * context, size_t, size_t, const char *) { if ( context ) { ((FirmataClass *)context)->printFirmwareVersion(); } }
     inline static void staticReportVersionCallback (void * context) { if ( context ) { ((FirmataClass *)context)->printVersion(); } }
     inline static void staticSystemResetCallback (void *) { if ( currentSystemResetCallback ) { currentSystemResetCallback(); } }
 };

--- a/FirmataParser.h
+++ b/FirmataParser.h
@@ -30,9 +30,10 @@ class FirmataParser
     /* callback function types */
     typedef void (*callbackFunction)(void * context, uint8_t command, uint16_t value);
     typedef void (*dataBufferOverflowCallbackFunction)(void * context);
-    typedef void (*stringCallbackFunction)(void * context, char * c_str);
+    typedef void (*stringCallbackFunction)(void * context, const char * c_str);
     typedef void (*sysexCallbackFunction)(void * context, uint8_t command, size_t argc, uint8_t * argv);
     typedef void (*systemCallbackFunction)(void * context);
+    typedef void (*versionCallbackFunction)(void * context, size_t sv_major, size_t sv_minor, const char * firmware);
 
     FirmataParser(uint8_t * dataBuffer = (uint8_t *)NULL, size_t dataBufferSize = 0);
 
@@ -47,6 +48,7 @@ class FirmataParser
     void attach(uint8_t command, stringCallbackFunction newFunction, void * context = NULL);
     void attach(uint8_t command, sysexCallbackFunction newFunction, void * context = NULL);
     void attach(uint8_t command, systemCallbackFunction newFunction, void * context = NULL);
+    void attach(uint8_t command, versionCallbackFunction newFunction, void * context = NULL);
     void detach(uint8_t command);
     void detach(dataBufferOverflowCallbackFunction);
 
@@ -87,14 +89,14 @@ class FirmataParser
     dataBufferOverflowCallbackFunction currentDataBufferOverflowCallback;
     stringCallbackFunction currentStringCallback;
     sysexCallbackFunction currentSysexCallback;
-    systemCallbackFunction currentReportFirmwareCallback;
+    versionCallbackFunction currentReportFirmwareCallback;
     systemCallbackFunction currentReportVersionCallback;
     systemCallbackFunction currentSystemResetCallback;
 
     /* private methods ------------------------------ */
+    bool bufferDataAtPosition(const uint8_t data, const size_t pos);
     void processSysexMessage(void);
     void systemReset(void);
-    bool bufferDataAtPosition(const uint8_t data, const size_t pos);
 };
 
 } // firmata


### PR DESCRIPTION
This provides maximum functionality without breaking API compatibility or a change in existing usage.

This works for `REPORT_FIRMWARE`, because it is wrapped in a sysex message. A sysex is parsed in its entirety before being processed, which allows us to uniformly invoke the callback and discard buffered bytes (or manage their absence) as we see fit.

This is tested and confirmed on the ESP8266, Uno and 101.