### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/test/readme.md
+++ b/test/readme.md
@@ -1,4 +1,4 @@
-#Testing Firmata
+# Testing Firmata
 
 Tests tests are written using the [ArduinoUnit](https://github.com/mmurdoch/arduinounit) library (version 2.0).
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
