### PR TITLE
Add support for Arduino MKRFox1200

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -247,7 +247,7 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #elif defined(ARDUINO_SAMD_MKR1000)
 #define TOTAL_ANALOG_PINS       7
 #define TOTAL_PINS              22 // 8 digital + 3 spi + 2 i2c + 2 uart + 7 analog
-#define IS_PIN_DIGITAL(p)       (((p) >= 0 && (p) <= 21) && !IS_PIN_SERIAL(p))
+#define IS_PIN_DIGITAL(p)       ((p) >= 0 && (p) <= 21)
 #define IS_PIN_ANALOG(p)        ((p) >= 15 && (p) < 15 + TOTAL_ANALOG_PINS)
 #define IS_PIN_PWM(p)           digitalPinHasPWM(p)
 #define IS_PIN_SERVO(p)         (IS_PIN_DIGITAL(p) && (p) < MAX_SERVOS) // deprecated since v2.4
@@ -264,7 +264,7 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #elif defined(ARDUINO_SAMD_MKRZERO)
 #define TOTAL_ANALOG_PINS       7
 #define TOTAL_PINS              34 // 8 digital + 3 spi + 2 i2c + 2 uart + 7 analog + 3 usb + 1 aref + 5 sd + 1 bottom pad + 1 led + 1 battery adc
-#define IS_PIN_DIGITAL(p)       ((((p) >= 0 && (p) <= 21) || (p) == 32) && !IS_PIN_SERIAL(p))
+#define IS_PIN_DIGITAL(p)       (((p) >= 0 && (p) <= 21) || (p) == 32)
 #define IS_PIN_ANALOG(p)        (((p) >= 15 && (p) < 15 + TOTAL_ANALOG_PINS) || (p) == 33)
 #define IS_PIN_PWM(p)           digitalPinHasPWM(p)
 #define IS_PIN_SERVO(p)         (IS_PIN_DIGITAL(p) && (p) < MAX_SERVOS) // deprecated since v2.4
@@ -280,7 +280,7 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #elif defined(ARDUINO_SAMD_MKRFox1200)
 #define TOTAL_ANALOG_PINS       7
 #define TOTAL_PINS              33 // 8 digital + 3 spi + 2 i2c + 2 uart + 7 analog + 3 usb + 1 aref + 5 sd + 1 bottom pad + 1 battery adc
-#define IS_PIN_DIGITAL(p)       ((((p) >= 0 && (p) <= 21)) && !IS_PIN_SERIAL(p))
+#define IS_PIN_DIGITAL(p)       (((p) >= 0 && (p) <= 21))
 #define IS_PIN_ANALOG(p)        (((p) >= 15 && (p) < 15 + TOTAL_ANALOG_PINS) || (p) == 32)
 #define IS_PIN_PWM(p)           digitalPinHasPWM(p)
 #define IS_PIN_SERVO(p)         (IS_PIN_DIGITAL(p) && (p) < MAX_SERVOS) // deprecated since v2.4

--- a/Boards.h
+++ b/Boards.h
@@ -276,6 +276,22 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #define PIN_TO_PWM(p)           PIN_TO_DIGITAL(p)
 #define PIN_TO_SERVO(p)         (p) // deprecated since v2.4
 
+// Arduino MKRFox1200
+#elif defined(ARDUINO_SAMD_MKRFox1200)
+#define TOTAL_ANALOG_PINS       7
+#define TOTAL_PINS              33 // 8 digital + 3 spi + 2 i2c + 2 uart + 7 analog + 3 usb + 1 aref + 5 sd + 1 bottom pad + 1 battery adc
+#define IS_PIN_DIGITAL(p)       ((((p) >= 0 && (p) <= 21)) && !IS_PIN_SERIAL(p))
+#define IS_PIN_ANALOG(p)        (((p) >= 15 && (p) < 15 + TOTAL_ANALOG_PINS) || (p) == 32)
+#define IS_PIN_PWM(p)           digitalPinHasPWM(p)
+#define IS_PIN_SERVO(p)         (IS_PIN_DIGITAL(p) && (p) < MAX_SERVOS) // deprecated since v2.4
+#define IS_PIN_I2C(p)           ((p) == 11 || (p) == 12) // SDA = 11, SCL = 12
+#define IS_PIN_SPI(p)           ((p) == SS || (p) == MOSI || (p) == MISO || (p) == SCK)
+#define IS_PIN_SERIAL(p)        ((p) == PIN_SERIAL1_RX || (p) == PIN_SERIAL1_TX) //defined in variant.h  RX = 13, TX = 14
+#define PIN_TO_DIGITAL(p)       (p)
+#define PIN_TO_ANALOG(p)        ((p) - 15)
+#define PIN_TO_PWM(p)           PIN_TO_DIGITAL(p)
+#define PIN_TO_SERVO(p)         (p) // deprecated since v2.4
+
 
 // Arduino Zero
 // Note this will work with an Arduino Zero Pro, but not with an Arduino M0 Pro


### PR DESCRIPTION
This adds support for the new Arduino MKRFox1200 board.

Please note that this board is only available in Europe for now, see: https://blog.arduino.cc/2017/04/18/introducing-the-arduino-mkrfox1200/


@agdl has briefly tested this change on with a MKRFox1200 and Johny-Five.