### PR TITLE
Single-Read Functionality. 

### DIFF
--- a/Firmata.cpp
+++ b/Firmata.cpp
@@ -36,6 +36,8 @@ callbackFunction FirmataClass::currentPinModeCallback = (callbackFunction)NULL;
 callbackFunction FirmataClass::currentPinValueCallback = (callbackFunction)NULL;
 callbackFunction FirmataClass::currentReportAnalogCallback = (callbackFunction)NULL;
 callbackFunction FirmataClass::currentReportDigitalCallback = (callbackFunction)NULL;
+callbackFunction FirmataClass::currentReadAnalogCallback = (callbackFunction)NULL;
+callbackFunction FirmataClass::currentReadDigitalCallback = (callbackFunction)NULL;
 stringCallbackFunction FirmataClass::currentStringCallback = (stringCallbackFunction)NULL;
 sysexCallbackFunction FirmataClass::currentSysexCallback = (sysexCallbackFunction)NULL;
 systemCallbackFunction FirmataClass::currentSystemResetCallback = (systemCallbackFunction)NULL;
@@ -90,6 +92,8 @@ FirmataClass::FirmataClass()
   parser.attach(DIGITAL_MESSAGE, (FirmataParser::callbackFunction)staticDigitalCallback, (void *)NULL);
   parser.attach(REPORT_ANALOG, (FirmataParser::callbackFunction)staticReportAnalogCallback, (void *)NULL);
   parser.attach(REPORT_DIGITAL, (FirmataParser::callbackFunction)staticReportDigitalCallback, (void *)NULL);
+  parser.attach(READ_ANALOG, (FirmataParser::callbackFunction)staticReadAnalogCallback, (void *)NULL);
+  parser.attach(READ_DIGITAL, (FirmataParser::callbackFunction)staticReadDigitalCallback, (void *)NULL);
   parser.attach(SET_PIN_MODE, (FirmataParser::callbackFunction)staticPinModeCallback, (void *)NULL);
   parser.attach(SET_DIGITAL_PIN_VALUE, (FirmataParser::callbackFunction)staticPinValueCallback, (void *)NULL);
   parser.attach(STRING_DATA, (FirmataParser::stringCallbackFunction)staticStringCallback, (void *)NULL);
@@ -395,6 +399,12 @@ void FirmataClass::attach(uint8_t command, ::callbackFunction newFunction)
       break;
     case REPORT_DIGITAL:
       currentReportDigitalCallback = newFunction;
+      break;
+    case READ_ANALOG:
+      currentReadAnalogCallback = newFunction;
+      break;
+    case READ_DIGITAL:
+      currentReadDigitalCallback = newFunction;
       break;
     case SET_PIN_MODE:
       currentPinModeCallback = newFunction;

--- a/Firmata.h
+++ b/Firmata.h
@@ -137,6 +137,8 @@ class FirmataClass
     static callbackFunction currentPinValueCallback;
     static callbackFunction currentReportAnalogCallback;
     static callbackFunction currentReportDigitalCallback;
+    static callbackFunction currentReadAnalogCallback;
+    static callbackFunction currentReadDigitalCallback;
     static stringCallbackFunction currentStringCallback;
     static sysexCallbackFunction currentSysexCallback;
     static systemCallbackFunction currentSystemResetCallback;
@@ -148,6 +150,8 @@ class FirmataClass
     inline static void staticPinValueCallback (void *, uint8_t command, uint16_t value) { if ( currentPinValueCallback ) { currentPinValueCallback(command, (int)value); } }
     inline static void staticReportAnalogCallback (void *, uint8_t command, uint16_t value) { if ( currentReportAnalogCallback ) { currentReportAnalogCallback(command, (int)value); } }
     inline static void staticReportDigitalCallback (void *, uint8_t command, uint16_t value) { if ( currentReportDigitalCallback ) { currentReportDigitalCallback(command, (int)value); } }
+    inline static void staticReadAnalogCallback ( void *, uint8_t command, uint16_t value) { if ( currentReadAnalogCallback ) { currentReadAnalogCallback(command, (int)value); } }
+    inline static void staticReadDigitalCallback ( void *, uint8_t command, uint16_t value) { if ( currentReadDigitalCallback ) { currentReadDigitalCallback(command, (int)value); } }
     inline static void staticStringCallback (void *, const char * c_str) { if ( currentStringCallback ) { currentStringCallback((char *)c_str); } }
     inline static void staticSysexCallback (void *, uint8_t command, size_t argc, uint8_t *argv) { if ( currentSysexCallback ) { currentSysexCallback(command, (uint8_t)argc, argv); } }
     inline static void staticReportFirmwareCallback (void * context, size_t, size_t, const char *) { if ( context ) { ((FirmataClass *)context)->printFirmwareVersion(); } }

--- a/FirmataConstants.h
+++ b/FirmataConstants.h
@@ -20,8 +20,8 @@ namespace firmata {
  * Query using the REPORT_FIRMWARE message.
  */
 static const int FIRMWARE_MAJOR_VERSION =  2;
-static const int FIRMWARE_MINOR_VERSION =  5;
-static const int FIRMWARE_BUGFIX_VERSION = 6;
+static const int FIRMWARE_MINOR_VERSION =  6;
+static const int FIRMWARE_BUGFIX_VERSION = 0;
 
 /* Version numbers for the protocol.  The protocol is still changing, so these
  * version numbers are important.
@@ -37,6 +37,8 @@ static const int MAX_DATA_BYTES =          64; // max number of data bytes in in
 
 static const int DIGITAL_MESSAGE =         0x90; // send data for a digital port (collection of 8 pins)
 static const int ANALOG_MESSAGE =          0xE0; // send data for an analog pin (or PWM)
+static const int READ_ANALOG =             0xA0; // single read of analog input by pin #
+static const int READ_DIGITAL =            0xB0; // single read of digital input by port pair
 static const int REPORT_ANALOG =           0xC0; // enable analog input by pin #
 static const int REPORT_DIGITAL =          0xD0; // enable digital input by port pair
 //

--- a/FirmataDefines.h
+++ b/FirmataDefines.h
@@ -49,6 +49,16 @@
 #endif
 #define ANALOG_MESSAGE          firmata::ANALOG_MESSAGE // send data for an analog pin (or PWM)
 
+#ifdef READ_ANALOG
+#undef READ_ANALOG
+#endif
+#define READ_ANALOG             firmata::READ_ANALOG // single read of analog input by pin #
+
+#ifdef READ_DIGITAL 
+#undef READ_DIGITAL
+#endif
+#define READ_DIGITAL            firmata::READ_DIGITAL // single read of digital input by port pair
+
 #ifdef REPORT_ANALOG
 #undef REPORT_ANALOG
 #endif

--- a/FirmataMarshaller.h
+++ b/FirmataMarshaller.h
@@ -45,6 +45,8 @@ class FirmataMarshaller
     void reportAnalogEnable(uint8_t pin) const;
     void reportDigitalPortDisable(uint8_t portNumber) const;
     void reportDigitalPortEnable(uint8_t portNumber) const;
+    void readAnalog(uint8_t pin) const;
+    void readDigitalPort(uint8_t portNumber)const;
     void sendAnalog(uint8_t pin, uint16_t value) const;
     void sendAnalogMappingQuery(void) const;
     void sendCapabilityQuery(void) const;

--- a/FirmataParser.cpp
+++ b/FirmataParser.cpp
@@ -16,7 +16,7 @@
 //******************************************************************************
 
 #include "FirmataParser.h"
-
+#include <Arduino.h>
 #include "FirmataConstants.h"
 
 using namespace firmata;
@@ -43,6 +43,8 @@ FirmataParser::FirmataParser(uint8_t * const dataBuffer, size_t dataBufferSize)
   currentDigitalCallbackContext((void *)NULL),
   currentReportAnalogCallbackContext((void *)NULL),
   currentReportDigitalCallbackContext((void *)NULL),
+  currentReadAnalogCallbackContext((void *)NULL),
+  currentReadDigitalCallbackContext((void *)NULL),
   currentPinModeCallbackContext((void *)NULL),
   currentPinValueCallbackContext((void *)NULL),
   currentReportFirmwareCallbackContext((void *)NULL),
@@ -55,6 +57,8 @@ FirmataParser::FirmataParser(uint8_t * const dataBuffer, size_t dataBufferSize)
   currentDigitalCallback((callbackFunction)NULL),
   currentReportAnalogCallback((callbackFunction)NULL),
   currentReportDigitalCallback((callbackFunction)NULL),
+  currentReadAnalogCallback((callbackFunction)NULL),
+  currentReadDigitalCallback((callbackFunction)NULL),
   currentPinModeCallback((callbackFunction)NULL),
   currentPinValueCallback((callbackFunction)NULL),
   currentDataBufferOverflowCallback((dataBufferOverflowCallbackFunction)NULL),
@@ -123,12 +127,21 @@ void FirmataParser::parse(uint8_t inputData)
             (*currentPinValueCallback)(currentPinValueCallbackContext, dataBuffer[1], dataBuffer[0]);
           break;
         case REPORT_ANALOG:
+          digitalWrite(13,1);
           if (currentReportAnalogCallback)
             (*currentReportAnalogCallback)(currentReportAnalogCallbackContext, multiByteChannel, dataBuffer[0]);
           break;
         case REPORT_DIGITAL:
           if (currentReportDigitalCallback)
             (*currentReportDigitalCallback)(currentReportDigitalCallbackContext, multiByteChannel, dataBuffer[0]);
+          break;
+        case READ_ANALOG:
+          if (currentReadAnalogCallback)
+            (*currentReadAnalogCallback)(currentReadAnalogCallbackContext, multiByteChannel, dataBuffer[0]);
+          break;
+        case READ_DIGITAL:
+          if (currentReadDigitalCallback)
+            (*currentReadDigitalCallback)(currentReadDigitalCallbackContext, multiByteChannel, dataBuffer[0]);
           break;
       }
       executeMultiByteCommand = 0;
@@ -152,6 +165,11 @@ void FirmataParser::parse(uint8_t inputData)
         break;
       case REPORT_ANALOG:
       case REPORT_DIGITAL:
+        waitForData = 1; // one data byte needed
+        executeMultiByteCommand = command;
+        break;
+      case READ_ANALOG:
+      case READ_DIGITAL:
         waitForData = 1; // one data byte needed
         executeMultiByteCommand = command;
         break;
@@ -231,6 +249,14 @@ void FirmataParser::attach(uint8_t command, callbackFunction newFunction, void *
     case REPORT_DIGITAL:
       currentReportDigitalCallback = newFunction;
       currentReportDigitalCallbackContext = context;
+      break;
+    case READ_ANALOG:
+      currentReadAnalogCallback = newFunction;
+      currentReadAnalogCallbackContext = context;
+      break;
+    case READ_DIGITAL:
+      currentReadDigitalCallback = newFunction;
+      currentReadDigitalCallbackContext = context;
       break;
     case SET_PIN_MODE:
       currentPinModeCallback = newFunction;

--- a/FirmataParser.cpp
+++ b/FirmataParser.cpp
@@ -16,7 +16,7 @@
 //******************************************************************************
 
 #include "FirmataParser.h"
-#include <Arduino.h>
+
 #include "FirmataConstants.h"
 
 using namespace firmata;

--- a/FirmataParser.cpp
+++ b/FirmataParser.cpp
@@ -127,7 +127,6 @@ void FirmataParser::parse(uint8_t inputData)
             (*currentPinValueCallback)(currentPinValueCallbackContext, dataBuffer[1], dataBuffer[0]);
           break;
         case REPORT_ANALOG:
-          digitalWrite(13,1);
           if (currentReportAnalogCallback)
             (*currentReportAnalogCallback)(currentReportAnalogCallbackContext, multiByteChannel, dataBuffer[0]);
           break;

--- a/FirmataParser.h
+++ b/FirmataParser.h
@@ -70,6 +70,8 @@ class FirmataParser
     void * currentDigitalCallbackContext;
     void * currentReportAnalogCallbackContext;
     void * currentReportDigitalCallbackContext;
+    void * currentReadAnalogCallbackContext;
+    void * currentReadDigitalCallbackContext;
     void * currentPinModeCallbackContext;
     void * currentPinValueCallbackContext;
     void * currentReportFirmwareCallbackContext;
@@ -84,6 +86,8 @@ class FirmataParser
     callbackFunction currentDigitalCallback;
     callbackFunction currentReportAnalogCallback;
     callbackFunction currentReportDigitalCallback;
+    callbackFunction currentReadAnalogCallback;
+    callbackFunction currentReadDigitalCallback;
     callbackFunction currentPinModeCallback;
     callbackFunction currentPinValueCallback;
     dataBufferOverflowCallbackFunction currentDataBufferOverflowCallback;

--- a/examples/StandardFirmata/StandardFirmata.ino
+++ b/examples/StandardFirmata/StandardFirmata.ino
@@ -26,6 +26,7 @@
 #include <Servo.h>
 #include <Wire.h>
 #include <Firmata.h>
+//#include <Arduino.h>
 
 #define I2C_WRITE                   B00000000
 #define I2C_READ                    B00001000
@@ -472,6 +473,35 @@ void reportDigitalCallback(byte port, int value)
   // pins configured as analog
 }
 
+// -----------------------------------------------------------------------------
+/* reads the value of an analog pin, then sends the value. Does not enable reporting.
+ */
+
+void readAnalogCallback(byte analogPin, int value)
+{
+  //#include <Arduino.h>
+  //digitalWrite(13,1);
+  if (analogPin < TOTAL_ANALOG_PINS) {
+    Firmata.sendAnalog(analogPin, analogRead(analogPin));
+  }
+}
+
+void readDigitalCallback(byte port, int value)
+{
+  if (port < TOTAL_PORTS) {
+    outputPort(port, readPort(port, portConfigInputs[port]), true);
+  }
+  /*
+  if (port < TOTAL_PORTS) {
+    reportPINs[port] = (byte)value;
+    // Send port value immediately. This is helpful when connected via
+    // ethernet, wi-fi or bluetooth so pin states can be known upon
+    // reconnecting.
+    if (value) outputPort(port, readPort(port, portConfigInputs[port]), true);
+  }
+  */
+}
+
 /*==============================================================================
  * SYSEX-BASED commands
  *============================================================================*/
@@ -760,6 +790,8 @@ void setup()
   Firmata.attach(DIGITAL_MESSAGE, digitalWriteCallback);
   Firmata.attach(REPORT_ANALOG, reportAnalogCallback);
   Firmata.attach(REPORT_DIGITAL, reportDigitalCallback);
+  Firmata.attach(READ_ANALOG, readAnalogCallback);
+  Firmata.attach(READ_DIGITAL, readDigitalCallback);
   Firmata.attach(SET_PIN_MODE, setPinModeCallback);
   Firmata.attach(SET_DIGITAL_PIN_VALUE, setPinValueCallback);
   Firmata.attach(START_SYSEX, sysexCallback);

--- a/examples/StandardFirmata/StandardFirmata.ino
+++ b/examples/StandardFirmata/StandardFirmata.ino
@@ -478,8 +478,6 @@ void reportDigitalCallback(byte port, int value)
 
 void readAnalogCallback(byte analogPin, int value)
 {
-  //#include <Arduino.h>
-  //digitalWrite(13,1);
   if (analogPin < TOTAL_ANALOG_PINS) {
     Firmata.sendAnalog(analogPin, analogRead(analogPin));
   }
@@ -490,15 +488,6 @@ void readDigitalCallback(byte port, int value)
   if (port < TOTAL_PORTS) {
     outputPort(port, readPort(port, portConfigInputs[port]), true);
   }
-  /*
-  if (port < TOTAL_PORTS) {
-    reportPINs[port] = (byte)value;
-    // Send port value immediately. This is helpful when connected via
-    // ethernet, wi-fi or bluetooth so pin states can be known upon
-    // reconnecting.
-    if (value) outputPort(port, readPort(port, portConfigInputs[port]), true);
-  }
-  */
 }
 
 /*==============================================================================

--- a/examples/StandardFirmata/StandardFirmata.ino
+++ b/examples/StandardFirmata/StandardFirmata.ino
@@ -26,7 +26,6 @@
 #include <Servo.h>
 #include <Wire.h>
 #include <Firmata.h>
-//#include <Arduino.h>
 
 #define I2C_WRITE                   B00000000
 #define I2C_READ                    B00001000


### PR DESCRIPTION
This adds the functionality to read a digital or analog pin, as opposed to the current method of reporting. This is useful in non-threaded environments, such as GNU Octave, when constant data is either a hindrance or unnecessary. 

The command uses the 0xA0 block to read an analog pin and 0xB0 to read a digital port. I did this to keep it in line with the analog and digital reporting commands, but it can be moved to a different block if this is not ideal. 

The structure of the new commands are identical to the reporting commands. It still requires a second byte, but the value is not checked. 

I have only updated the StandardFirmata.ino to accommodate this change right now, but I can update the others if this merge is accepted. 

Since this adds new functionality, I also changed the version from 2.5.6 to 2.6.0. 