### PR TITLE
Add support for STM32 MCU based boards

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -780,6 +780,26 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #define PIN_TO_SERVO(p)         (p)
 #define DEFAULT_PWM_RESOLUTION  10
 
+// STM32 based boards
+#elif defined(ARDUINO_ARCH_STM32)
+#define TOTAL_ANALOG_PINS       NUM_ANALOG_INPUTS
+#define TOTAL_PINS              NUM_DIGITAL_PINS
+#define TOTAL_PORTS             MAX_NB_PORT
+#define VERSION_BLINK_PIN       LED_BUILTIN
+// PIN_SERIALY_RX/TX defined in the variant.h
+#define IS_PIN_DIGITAL(p)       (digitalPinIsValid(p) && !pinIsSerial(p))
+#define IS_PIN_ANALOG(p)        ((p >= A0) && (p < AEND) && !pinIsSerial(p))
+#define IS_PIN_PWM(p)           (IS_PIN_DIGITAL(p) && digitalPinHasPWM(p))
+#define IS_PIN_SERVO(p)         IS_PIN_DIGITAL(p)
+#define IS_PIN_I2C(p)           (IS_PIN_DIGITAL(p) && digitalPinHasI2C(p))
+#define IS_PIN_SPI(p)           (IS_PIN_DIGITAL(p) && digitalPinHasSPI(p))
+#define IS_PIN_INTERRUPT(p)     (IS_PIN_DIGITAL(p) && (digitalPinToInterrupt(p) > NOT_AN_INTERRUPT)))
+#define IS_PIN_SERIAL(p)        (digitalPinHasSerial(p) && !pinIsSerial(p))
+#define PIN_TO_DIGITAL(p)       (p)
+#define PIN_TO_ANALOG(p)        (p-A0)
+#define PIN_TO_PWM(p)           (p)
+#define PIN_TO_SERVO(p)         (p)
+#define DEFAULT_PWM_RESOLUTION  PWM_RESOLUTION
 
 // anything else
 #else


### PR DESCRIPTION
Hi,

This PR add the support of STM32 MCU based board.
More information here: [STM32 cores enabled in Arduino IDE](https://community.st.com/community/stm32-community/blog/2017/02/02/stm32-cores-enabled-in-arduino-ide)
Latest release of the [Arduino_Core_STM32](https://github.com/stm32duino/Arduino_Core_STM32) is functional with Firmata. The modified lib with ARDUINO_ARCH_STM32 is currently released with the core and could be removed when this PR will be merged.
Core is provided as a package thanks the Arduino Boards manager, see the [wiki](https://github.com/stm32duino/wiki/wiki/Getting-Started)

Thanks in advance