### PR TITLE
Add support for Arduino MKR WAN 1300 and MKR GSM 1400

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -292,6 +292,37 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #define PIN_TO_PWM(p)           PIN_TO_DIGITAL(p)
 #define PIN_TO_SERVO(p)         (p) // deprecated since v2.4
 
+// Arduino MKR WAN 1300
+#elif defined(ARDUINO_SAMD_MKRWAN1300)
+#define TOTAL_ANALOG_PINS       7
+#define TOTAL_PINS              33
+#define IS_PIN_DIGITAL(p)       (((p) >= 0 && (p) <= 21))
+#define IS_PIN_ANALOG(p)        (((p) >= 15 && (p) < 15 + TOTAL_ANALOG_PINS) || (p) == 32)
+#define IS_PIN_PWM(p)           digitalPinHasPWM(p)
+#define IS_PIN_SERVO(p)         (IS_PIN_DIGITAL(p) && (p) < MAX_SERVOS) // deprecated since v2.4
+#define IS_PIN_I2C(p)           ((p) == 11 || (p) == 12) // SDA = 11, SCL = 12
+#define IS_PIN_SPI(p)           ((p) == SS || (p) == MOSI || (p) == MISO || (p) == SCK)
+#define IS_PIN_SERIAL(p)        ((p) == PIN_SERIAL1_RX || (p) == PIN_SERIAL1_TX) //defined in variant.h  RX = 13, TX = 14
+#define PIN_TO_DIGITAL(p)       (p)
+#define PIN_TO_ANALOG(p)        ((p) - 15)
+#define PIN_TO_PWM(p)           PIN_TO_DIGITAL(p)
+#define PIN_TO_SERVO(p)         (p) // deprecated since v2.4
+
+// Arduino MKR GSM 1400
+#elif defined(ARDUINO_SAMD_MKRGSM1400)
+#define TOTAL_ANALOG_PINS       7
+#define TOTAL_PINS              33
+#define IS_PIN_DIGITAL(p)       (((p) >= 0 && (p) <= 21))
+#define IS_PIN_ANALOG(p)        (((p) >= 15 && (p) < 15 + TOTAL_ANALOG_PINS) || (p) == 32)
+#define IS_PIN_PWM(p)           digitalPinHasPWM(p)
+#define IS_PIN_SERVO(p)         (IS_PIN_DIGITAL(p) && (p) < MAX_SERVOS) // deprecated since v2.4
+#define IS_PIN_I2C(p)           ((p) == 11 || (p) == 12) // SDA = 11, SCL = 12
+#define IS_PIN_SPI(p)           ((p) == SS || (p) == MOSI || (p) == MISO || (p) == SCK)
+#define IS_PIN_SERIAL(p)        ((p) == PIN_SERIAL1_RX || (p) == PIN_SERIAL1_TX) //defined in variant.h  RX = 13, TX = 14
+#define PIN_TO_DIGITAL(p)       (p)
+#define PIN_TO_ANALOG(p)        ((p) - 15)
+#define PIN_TO_PWM(p)           PIN_TO_DIGITAL(p)
+#define PIN_TO_SERVO(p)         (p) // deprecated since v2.4
 
 // Arduino Zero
 // Note this will work with an Arduino Zero Pro, but not with an Arduino M0 Pro


### PR DESCRIPTION
I've based this on the MKR FOX 1200 definition, and left the highest pin as 32 for the battery ADC. There more pins above 32 defined in the variants but they are used for the LoRaWAN and cellular modules on the boards.

Variants for the new boards are available with the new Arduino SAMD 1.6.17 core release:
 * https://github.com/arduino/ArduinoCore-samd/blob/master/variants/mkrwan1300/variant.h
 * https://github.com/arduino/ArduinoCore-samd/blob/master/variants/mkrgsm1400/variant.h