### PR TITLE
[STM32] Avoid using non standard constant

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -788,7 +788,7 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #define VERSION_BLINK_PIN       LED_BUILTIN
 // PIN_SERIALY_RX/TX defined in the variant.h
 #define IS_PIN_DIGITAL(p)       (digitalPinIsValid(p) && !pinIsSerial(p))
-#define IS_PIN_ANALOG(p)        ((p >= A0) && (p < AEND) && !pinIsSerial(p))
+#define IS_PIN_ANALOG(p)        ((p >= A0) && (p < (A0 + TOTAL_ANALOG_PINS)) && !pinIsSerial(p))
 #define IS_PIN_PWM(p)           (IS_PIN_DIGITAL(p) && digitalPinHasPWM(p))
 #define IS_PIN_SERVO(p)         IS_PIN_DIGITAL(p)
 #define IS_PIN_I2C(p)           (IS_PIN_DIGITAL(p) && digitalPinHasI2C(p))


### PR DESCRIPTION
AEND is an internal STM32 core constant and should not be used.
Replaced by (A0 + TOTAL_ANALOG_PINS)
