### PR TITLE
Add support for Adafruit Feather M0 Bluefruit LE to StandardFirmataBLE

### DIFF
--- a/examples/StandardFirmataBLE/StandardFirmataBLE.ino
+++ b/examples/StandardFirmataBLE/StandardFirmataBLE.ino
@@ -768,6 +768,13 @@ void setup()
   Firmata.attach(START_SYSEX, sysexCallback);
   Firmata.attach(SYSTEM_RESET, systemResetCallback);
 
+  stream.setLocalName(FIRMATA_BLE_LOCAL_NAME);
+
+  // set the BLE connection interval - this is the fastest interval you can read inputs
+  stream.setConnectionInterval(FIRMATA_BLE_MIN_INTERVAL, FIRMATA_BLE_MAX_INTERVAL);
+  // set how often the BLE TX buffer is flushed (if not full)
+  stream.setFlushInterval(FIRMATA_BLE_TXBUFFER_FLUSH_INTERVAL);
+
 #ifdef IS_IGNORE_BLE_PINS
   for (byte i = 0; i < TOTAL_PINS; i++) {
     if (IS_IGNORE_BLE_PINS(i)) {

--- a/examples/StandardFirmataBLE/StandardFirmataBLE.ino
+++ b/examples/StandardFirmataBLE/StandardFirmataBLE.ino
@@ -768,7 +768,7 @@ void setup()
   Firmata.attach(START_SYSEX, sysexCallback);
   Firmata.attach(SYSTEM_RESET, systemResetCallback);
 
-#ifdef BLE_REQ
+#ifdef IS_IGNORE_BLE_PINS
   for (byte i = 0; i < TOTAL_PINS; i++) {
     if (IS_IGNORE_BLE_PINS(i)) {
       Firmata.setPinMode(i, PIN_MODE_IGNORE);

--- a/examples/StandardFirmataBLE/StandardFirmataBLE.ino
+++ b/examples/StandardFirmataBLE/StandardFirmataBLE.ino
@@ -56,10 +56,6 @@
 // the minimum interval for sampling analog input
 #define MINIMUM_SAMPLING_INTERVAL   1
 
-// min cannot be < 0x0006. Adjust max if necessary
-#define FIRMATA_BLE_MIN_INTERVAL    0x0006 // 7.5ms (7.5 / 1.25)
-#define FIRMATA_BLE_MAX_INTERVAL    0x0018 // 30ms (30 / 1.25)
-
 /*==============================================================================
  * GLOBAL VARIABLES
  *============================================================================*/
@@ -771,13 +767,6 @@ void setup()
   Firmata.attach(SET_DIGITAL_PIN_VALUE, setPinValueCallback);
   Firmata.attach(START_SYSEX, sysexCallback);
   Firmata.attach(SYSTEM_RESET, systemResetCallback);
-
-  stream.setLocalName(FIRMATA_BLE_LOCAL_NAME);
-
-  // set the BLE connection interval - this is the fastest interval you can read inputs
-  stream.setConnectionInterval(FIRMATA_BLE_MIN_INTERVAL, FIRMATA_BLE_MAX_INTERVAL);
-  // set how often the BLE TX buffer is flushed (if not full)
-  stream.setFlushInterval(FIRMATA_BLE_MAX_INTERVAL);
 
 #ifdef BLE_REQ
   for (byte i = 0; i < TOTAL_PINS; i++) {

--- a/examples/StandardFirmataBLE/bleConfig.h
+++ b/examples/StandardFirmataBLE/bleConfig.h
@@ -88,7 +88,6 @@
  * Generic settings
  */
 #if !defined(FIRMATA_BLE_MIN_INTERVAL) && !defined(FIRMATA_BLE_MAX_INTERVAL)
-// BLE connection interval - this is the fastest interval you can read inputs.
 // These values apply to all devices using the Arduino BLEPeripheral library
 // with a Nordic nRF8001 or nRF51822.  Both values must be between
 // 0x0006 (7.5ms) and 0x0c80 (4s).
@@ -97,7 +96,6 @@
 #endif
 
 #if !defined(FIRMATA_BLE_TXBUFFER_FLUSH_INTERVAL)
-// How often the BLE TX buffer is flushed (if not full)
 #define FIRMATA_BLE_TXBUFFER_FLUSH_INTERVAL 30 // 30ms
 #endif
 

--- a/examples/StandardFirmataBLE/bleConfig.h
+++ b/examples/StandardFirmataBLE/bleConfig.h
@@ -5,7 +5,7 @@
  * need a unique ble local name (see below). If you are using another supported BLE board or shield,
  * follow the instructions for the specific board or shield below.
  *
- * Make sure you have the Intel Curie Boards package v1.0.6 or higher installed via the Arduino
+ * Make sure you have the Intel Curie Boards package v2.0.2 or higher installed via the Arduino
  * Boards Manager.
  *
  * Supported boards and shields:
@@ -18,6 +18,22 @@
 // change this to a unique name per board if running StandardFirmataBLE on multiple boards
 // within the same physical space
 #define FIRMATA_BLE_LOCAL_NAME "FIRMATA"
+
+/*
+ * Arduino 101
+ *
+ * Make sure you have the Intel Curie Boards package v2.0.2 or higher installed via the Arduino
+ * Boards Manager.
+ *
+ * Test script: https://gist.github.com/soundanalogous/927360b797574ed50e27
+ */
+#ifdef _VARIANT_ARDUINO_101_X_
+// After conversion to units of 1.25ms, both values must be between
+// 0x0006 (7.5ms) and 0x0c80 (4s)
+#define FIRMATA_BLE_MIN_INTERVAL 8  // ( 8 * 1000) / 1250 == 0x06 -> 7.5ms
+#define FIRMATA_BLE_MAX_INTERVAL 30 // (30 * 1000) / 1250 == 0x18 -> 30ms
+#endif
+
 
 /*
  * RedBearLab BLE Shield
@@ -36,15 +52,27 @@
 //#define REDBEAR_BLE_SHIELD
 
 #ifdef REDBEAR_BLE_SHIELD
-#include <SPI.h>
-#include <BLEPeripheral.h>
-#include "utility/BLEStream.h"
-
 #define BLE_REQ  9
 #define BLE_RDY  8
 #define BLE_RST  4 // 4 or 7 via jumper on shield
+#endif
 
-BLEStream stream(BLE_REQ, BLE_RDY, BLE_RST);
+
+/*
+ * Generic settings
+ */
+#if !defined(FIRMATA_BLE_MIN_INTERVAL) && !defined(FIRMATA_BLE_MAX_INTERVAL)
+// BLE connection interval - this is the fastest interval you can read inputs.
+// These values apply to all devices using the Arduino BLEPeripheral library
+// with a Nordic nRF8001 or nRF51822.  Both values must be between
+// 0x0006 (7.5ms) and 0x0c80 (4s).
+#define FIRMATA_BLE_MIN_INTERVAL 0x0006 // 7.5ms (7.5 / 1.25)
+#define FIRMATA_BLE_MAX_INTERVAL 0x0018 // 30ms (30 / 1.25)
+#endif
+
+#if !defined(FIRMATA_BLE_TXBUFFER_FLUSH_INTERVAL)
+// How often the BLE TX buffer is flushed (if not full)
+#define FIRMATA_BLE_TXBUFFER_FLUSH_INTERVAL 30 // 30ms
 #endif
 
 
@@ -52,18 +80,16 @@ BLEStream stream(BLE_REQ, BLE_RDY, BLE_RST);
  * END BLE CONFIGURATION - you should not need to change anything below this line
  *================================================================================================*/
 
-/*
- * Arduino 101
- *
- * Make sure you have the Intel Curie Boards package v1.0.6 or higher installed via the Arduino
- * Boards Manager.
- *
- * Test script: https://gist.github.com/soundanalogous/927360b797574ed50e27
- */
 #ifdef _VARIANT_ARDUINO_101_X_
-#include <CurieBLE.h>
 #include "utility/BLEStream.h"
 BLEStream stream;
+#endif
+
+
+#ifdef REDBEAR_BLE_SHIELD
+#include <SPI.h>
+#include "utility/BLEStream.h"
+BLEStream stream(BLE_REQ, BLE_RDY, BLE_RST);
 #endif
 
 
@@ -81,7 +107,6 @@ BLEStream stream;
  * the pins are currently mapped in Firmata only for the default (factory) jumper settings.
  */
 // #ifdef BLE_NANO
-// #include <BLEPeripheral.h>
 // #include "utility/BLEStream.h"
 // BLEStream stream;
 // #endif
@@ -96,7 +121,6 @@ BLEStream stream;
  */
 // #if defined(BLEND_MICRO) || defined(BLEND)
 // #include <SPI.h>
-// #include <BLEPeripheral.h>
 // #include "utility/BLEStream.h"
 
 // #define BLE_REQ  6

--- a/examples/StandardFirmataBLE/bleConfig.h
+++ b/examples/StandardFirmataBLE/bleConfig.h
@@ -12,6 +12,7 @@
  * - Arduino 101 (recommended)
  * - RedBearLab BLE Shield (v2)  ** to be verified **
  * - RedBearLab BLE Nano ** works with modifications **
+ * - Adafruit Feather M0 Bluefruit LE
  *
  *================================================================================================*/
 
@@ -59,6 +60,31 @@
 
 
 /*
+ * Adafruit Feather M0 Bluefruit LE
+ *
+ * If you are using an Adafruit Feather M0 Bluefruit LE, uncomment the define below.
+ * This configuration should also work with other Bluefruit LE boards/modules that communicate
+ * with the nRF51822 via SPI (e.g. Bluefruit LE SPI Friend, Bluefruit LE Shield), although
+ * you may need to change the values of BLE_SPI_CS, BLE_SPI_IRQ, and/or BLE_SPI_RST below.
+ *
+ * You will need to install a lightly-modified version of the Adafruit BluefruitLE nRF51
+ * package, available at:
+ * https://github.com/cstawarz/Adafruit_BluefruitLE_nRF51/archive/firmata_fixes.zip
+ */
+//#define BLUEFRUIT_LE_SPI
+
+#ifdef BLUEFRUIT_LE_SPI
+// Both values must be between 10ms and 4s
+#define FIRMATA_BLE_MIN_INTERVAL 10 // 10ms
+#define FIRMATA_BLE_MAX_INTERVAL 20 // 20ms
+
+#define BLE_SPI_CS   8
+#define BLE_SPI_IRQ  7
+#define BLE_SPI_RST  4
+#endif
+
+
+/*
  * Generic settings
  */
 #if !defined(FIRMATA_BLE_MIN_INTERVAL) && !defined(FIRMATA_BLE_MAX_INTERVAL)
@@ -90,6 +116,12 @@ BLEStream stream;
 #include <SPI.h>
 #include "utility/BLEStream.h"
 BLEStream stream(BLE_REQ, BLE_RDY, BLE_RST);
+#endif
+
+
+#ifdef BLUEFRUIT_LE_SPI
+#include "utility/BluefruitLE_SPI_Stream.h"
+BluefruitLE_SPI_Stream stream(BLE_SPI_CS, BLE_SPI_IRQ, BLE_SPI_RST);
 #endif
 
 
@@ -133,4 +165,6 @@ BLEStream stream(BLE_REQ, BLE_RDY, BLE_RST);
 
 #if defined(BLE_REQ) && defined(BLE_RDY) && defined(BLE_RST)
 #define IS_IGNORE_BLE_PINS(p) ((p) == BLE_REQ || (p) == BLE_RDY || (p) == BLE_RST)
+#elif defined(BLE_SPI_CS) && defined(BLE_SPI_IRQ) && defined(BLE_SPI_RST)
+#define IS_IGNORE_BLE_PINS(p) ((p) == BLE_SPI_CS || (p) == BLE_SPI_IRQ || (p) == BLE_SPI_RST)
 #endif

--- a/utility/BLEStream.h
+++ b/utility/BLEStream.h
@@ -19,9 +19,6 @@
 #define _MAX_ATTR_DATA_LEN_ BLE_ATTRIBUTE_MAX_VALUE_LENGTH
 #endif
 
-#define BLESTREAM_TXBUFFER_FLUSH_INTERVAL 80
-#define BLESTREAM_MIN_FLUSH_INTERVAL 8 // minimum interval for flushing the TX buffer
-
 // #define BLE_SERIAL_DEBUG
 
 class BLEStream : public BLEPeripheral, public Stream
@@ -32,7 +29,6 @@ class BLEStream : public BLEPeripheral, public Stream
     void begin(...);
     bool poll();
     void end();
-    void setFlushInterval(int);
 
     virtual int available(void);
     virtual int peek(void);
@@ -45,7 +41,6 @@ class BLEStream : public BLEPeripheral, public Stream
   private:
     bool _connected;
     unsigned long _flushed;
-    int _flushInterval;
     static BLEStream* _instance;
 
     size_t _rxHead;
@@ -85,7 +80,6 @@ BLEStream::BLEStream(unsigned char req, unsigned char rdy, unsigned char rst) :
   this->_txCount = 0;
   this->_rxHead = this->_rxTail = 0;
   this->_flushed = 0;
-  this->_flushInterval = BLESTREAM_TXBUFFER_FLUSH_INTERVAL;
   BLEStream::_instance = this;
 
   addAttribute(this->_uartService);
@@ -100,6 +94,8 @@ BLEStream::BLEStream(unsigned char req, unsigned char rdy, unsigned char rst) :
 
 void BLEStream::begin(...)
 {
+  BLEPeripheral::setLocalName(FIRMATA_BLE_LOCAL_NAME);
+  BLEPeripheral::setConnectionInterval(FIRMATA_BLE_MIN_INTERVAL, FIRMATA_BLE_MAX_INTERVAL);
   BLEPeripheral::begin();
 #ifdef BLE_SERIAL_DEBUG
   Serial.println(F("BLEStream::begin()"));
@@ -110,7 +106,7 @@ bool BLEStream::poll()
 {
   // BLEPeripheral::poll is called each time connected() is called
   this->_connected = BLEPeripheral::connected();
-  if (millis() > this->_flushed + this->_flushInterval) {
+  if (millis() > this->_flushed + FIRMATA_BLE_TXBUFFER_FLUSH_INTERVAL) {
     flush();
   }
   return this->_connected;
@@ -212,13 +208,6 @@ BLEStream::operator bool()
   Serial.println(retval);
 #endif
   return retval;
-}
-
-void BLEStream::setFlushInterval(int interval)
-{
-  if (interval > BLESTREAM_MIN_FLUSH_INTERVAL) {
-    this->_flushInterval = interval;
-  }
 }
 
 void BLEStream::_received(const unsigned char* data, size_t size)

--- a/utility/BluefruitLE_SPI_Stream.cpp
+++ b/utility/BluefruitLE_SPI_Stream.cpp
@@ -1,0 +1,3 @@
+/*
+ * Implementation is in BluefruitLE_SPI_Stream.h to avoid linker issues.
+ */

--- a/utility/BluefruitLE_SPI_Stream.h
+++ b/utility/BluefruitLE_SPI_Stream.h
@@ -1,0 +1,127 @@
+/*
+  BluefruitLE_SPI_Stream.h
+
+  Documentation for the various AT commands used below is available at
+  https://learn.adafruit.com/adafruit-feather-m0-bluefruit-le/at-commands
+ */
+
+#ifndef _BLUEFRUIT_LE_SPI_STREAM_H_
+#define _BLUEFRUIT_LE_SPI_STREAM_H_
+
+#include <Adafruit_BluefruitLE_SPI.h>
+
+
+class BluefruitLE_SPI_Stream : public Stream
+{
+  public:
+    BluefruitLE_SPI_Stream(int8_t csPin, int8_t irqPin, int8_t rstPin);
+
+    void begin();
+    bool poll();
+    void end();
+
+    // Print overrides
+    size_t write(uint8_t byte);
+    using Print::write;  // Expose other write variants
+
+    // Stream overrides
+    int available();
+    int read();
+    int peek();
+    void flush();
+
+  private:
+    Adafruit_BluefruitLE_SPI ble;
+
+    uint8_t txBuffer[SDEP_MAX_PACKETSIZE];
+    size_t txCount;
+};
+
+
+BluefruitLE_SPI_Stream::BluefruitLE_SPI_Stream(int8_t csPin, int8_t irqPin, int8_t rstPin) :
+  ble(csPin, irqPin, rstPin),
+  txCount(0)
+{ }
+
+void BluefruitLE_SPI_Stream::begin()
+{
+  // Initialize the SPI interface
+  ble.begin();
+
+  // Perform a factory reset to make sure everything is in a known state
+  ble.factoryReset();
+
+  // Disable command echo from Bluefruit
+  ble.echo(false);
+
+  // Change the MODE LED to indicate BLE UART activity
+  ble.println("AT+HWMODELED=BLEUART");
+
+  // Set local name
+  ble.print("AT+GAPDEVNAME=");
+  ble.println(FIRMATA_BLE_LOCAL_NAME);
+
+  // Set connection interval
+  ble.print("AT+GAPINTERVALS=");
+  ble.print(FIRMATA_BLE_MIN_INTERVAL);
+  ble.print(",");
+  ble.print(FIRMATA_BLE_MAX_INTERVAL);
+  ble.println(",,,");
+
+  // Disable real and simulated mode switch (i.e. "+++") command
+  ble.println("AT+MODESWITCHEN=local,0");
+  ble.enableModeSwitchCommand(false);
+
+  // Switch to data mode
+  ble.setMode(BLUEFRUIT_MODE_DATA);
+}
+
+bool BluefruitLE_SPI_Stream::poll()
+{
+  // If there's outgoing data in the buffer, just send it.  The firmware on
+  // the nRF51822 will decide when to transmit the data in its TX FIFO.
+  if (txCount) flush();
+
+  // In order to check for a connection, we would need to switch from data to
+  // command mode and back again.  However, due to the internal workings of
+  // Adafruit_BluefruitLE_SPI, this can lead to unread incoming data being
+  // lost.  Therefore, we always return true.
+  return true;
+}
+
+void BluefruitLE_SPI_Stream::end()
+{
+  flush();
+  ble.end();
+}
+
+size_t BluefruitLE_SPI_Stream::write(uint8_t byte)
+{
+  txBuffer[txCount++] = byte;
+  if (txCount == sizeof(txBuffer)) flush();
+  return 1;
+}
+
+int BluefruitLE_SPI_Stream::available()
+{
+  return ble.available();
+}
+
+int BluefruitLE_SPI_Stream::read()
+{
+  return ble.read();
+}
+
+int BluefruitLE_SPI_Stream::peek()
+{
+  return ble.peek();
+}
+
+void BluefruitLE_SPI_Stream::flush()
+{
+  ble.write(txBuffer, txCount);
+  txCount = 0;
+}
+
+
+#endif // _BLUEFRUIT_LE_SPI_STREAM_H_


### PR DESCRIPTION
These changes add support for the [Adafruit Feather M0 Bluefruit LE](https://www.adafruit.com/product/2995) board to StandardFirmataBLE.  They should also work with other Bluefruit LE boards/modules that communicate with the nRF51822 via SPI, although I've only tested the Feather M0.  The changes require a few [small modifications](https://github.com/cstawarz/Adafruit_BluefruitLE_nRF51/tree/firmata_fixes) to the Adafruit BluefruitLE nRF51 package (pull request: adafruit/Adafruit_BluefruitLE_nRF51#43).

I also moved the configuration of the BLE connection and flush intervals to bleConfig.h and updated the connection interval values for the Arduino 101 (which, as of Intel Curie Boards package v2.0.2, must be given in units of milliseconds, not 1.25ms).

I tested the changes on both an Arduino 101 and a Feather M0 Bluefruit LE.