### PR TITLE
Add PulseIn Implementation

### DIFF
--- a/Firmata.h
+++ b/Firmata.h
@@ -33,6 +33,7 @@
 #define SYSEX_I2C_REQUEST       0x76 // same as I2C_REQUEST
 #define SYSEX_I2C_REPLY         0x77 // same as I2C_REPLY
 #define SYSEX_SAMPLING_INTERVAL 0x7A // same as SAMPLING_INTERVAL
+#define PULSE_IN                0x74 // send a pulse in command
 
 // pin modes
 //#define INPUT                 0x00 // defined in Arduino.h


### PR DESCRIPTION
Add support for implementing the arduino pulseIn method and exposing that thru Firmata. Specifically needed for ultrasonic ranging sensors that use a pulse to measure distances. Polling the pin state over the network using a firmata client to take measurements is too noisy. The network latency is never going to be fast or stable enough to get any sort of accuracy for these timing-based sensors. 

The time differential needed to compute measurements on these type of sensors, I believe, really needs to be done on the hardware itself.  Network latency can add +-10 full milliseconds even under the best conditions. (Plus it would stink to have measurements change as a function of distance from wifi router.)

This code was taken from: @jgautier ['s arduino fork](https://github.com/jgautier/arduino-1), 
Architectural approach from: @NeoPolus - [pyFirmata#45](https://github.com/tino/pyFirmata/pull/45)
Relevant threads with gobot client: 
 - [361](https://github.com/hybridgroup/gobot/issues/361)
 - [152](https://github.com/hybridgroup/gobot/issues/152)
 - [246](https://github.com/hybridgroup/gobot/issues/246)
