### PR TITLE
Remove invalid reference links from keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,10 +7,10 @@
 #######################################
 
 Firmata	KEYWORD1	Firmata
-callbackFunction	KEYWORD1	callbackFunction
-systemResetCallbackFunction	KEYWORD1	systemResetCallbackFunction
-stringCallbackFunction	KEYWORD1	stringCallbackFunction
-sysexCallbackFunction	KEYWORD1	sysexCallbackFunction
+callbackFunction	KEYWORD1
+systemResetCallbackFunction	KEYWORD1
+stringCallbackFunction	KEYWORD1
+sysexCallbackFunction	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)


### PR DESCRIPTION
The third field of keywords.txt is used to provide Arduino Language/Libraries Reference links, which are accessed from the Arduino IDE by highlighting the keyword and then selecting "Find in Reference" from the Help or right click menu. Adding values to this field that do not match any existing reference pages results in a "Could not open the URL" error.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywordstxt-format