### PR TITLE
Support for Sanguino/Melzi, e.g. Creality Ender-3

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -590,6 +590,25 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #define PIN_TO_PWM(p)           PIN_TO_DIGITAL(p)
 #define PIN_TO_SERVO(p)         ((p) - 2)
 
+// Sanguino/Melzi, e.g. Creality Ender-3
+#elif defined(__AVR_ATmega1284P__)
+#define TOTAL_ANALOG_PINS       8
+#define TOTAL_PINS              32 
+#define VERSION_BLINK_PIN       13
+#define PIN_SERIAL1_RX          8 //PD0
+#define PIN_SERIAL1_TX          9 //PD1
+#define IS_PIN_DIGITAL(p)       ((p) >= 0 && (p) < TOTAL_PINS)
+#define IS_PIN_ANALOG(p)        ((p) >= 24 && (p) < TOTAL_PINS)
+#define IS_PIN_PWM(p)           ((p) == 3 || (p) == 4 || (p) == 6 || (p) == 7 || (p) == 12 || (p) == 13 || (p) == 14 || (p) == 15)
+#define IS_PIN_SERVO(p)         ((p) >= 0 && (p) < MAX_SERVOS)
+#define IS_PIN_I2C(p)           ((p) == 16 || (p) == 17)
+#define IS_PIN_SPI(p)           ((p) == SS || (p) == MOSI || (p) == MISO || (p) == SCK)
+#define IS_PIN_SERIAL(p)        ((p) == 8 || (p) == 9)
+#define PIN_TO_DIGITAL(p)       (p)
+#define PIN_TO_ANALOG(p)        (p) - 24
+#define PIN_TO_PWM(p)           PIN_TO_DIGITAL(p)
+#define PIN_TO_SERVO(p)         (p)
+
 
 // Illuminato
 #elif defined(__AVR_ATmega645__)


### PR DESCRIPTION
Ran into this issue when compiling Marlin v2 for the Creality Ender-3

See also #281