### PR TITLE
Add support for Arduino MKR WiFi 1010

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -261,8 +261,8 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #define PIN_TO_SERVO(p)         ((p) - 2)
 
 
-// Arduino/Genuino MKR1000
-#elif defined(ARDUINO_SAMD_MKR1000)
+// Arduino/Genuino MKR1000 or MKR1010
+#elif defined(ARDUINO_SAMD_MKR1000)	|| defined(ARDUINO_SAMD_MKRWIFI1010)
 #define TOTAL_ANALOG_PINS       7
 #define TOTAL_PINS              22 // 8 digital + 3 spi + 2 i2c + 2 uart + 7 analog
 #define IS_PIN_DIGITAL(p)       ((p) >= 0 && (p) <= 21)

--- a/examples/StandardFirmataWiFi/StandardFirmataWiFi.ino
+++ b/examples/StandardFirmataWiFi/StandardFirmataWiFi.ino
@@ -37,6 +37,7 @@
   - Arduino WiFi Shield (or clone)
   - Arduino WiFi Shield 101
   - Arduino MKR1000 board
+  - Arduino MKRWIFI1010 board
   - ESP8266 WiFi board compatible with ESP8266 Arduino core
 
   Follow the instructions in the wifiConfig.h file (wifiConfig.h tab in Arduino IDE) to
@@ -929,6 +930,8 @@ void initTransport()
   DEBUG_PRINTLN( "using the ESP8266 WiFi library." );
 #elif defined(HUZZAH_WIFI)
   DEBUG_PRINTLN( "using the HUZZAH WiFi library." );
+#elif defined(WIFI_NINA)
+  DEBUG_PRINTLN( "using the WiFi NINA library." );
   //else should never happen here as error-checking in wifiConfig.h will catch this
 #endif  //defined(WIFI_101)
 

--- a/examples/StandardFirmataWiFi/wifiConfig.h
+++ b/examples/StandardFirmataWiFi/wifiConfig.h
@@ -102,6 +102,41 @@
  * For HUZZAH with ESP8266 use ESP8266_WIFI.
  */
 
+/*
+ * OPTION E: Configure for Arduino MKR WiFi 1010 and maybe other WiFiNINA boards.
+ *
+ * This will configure StandardFirmataWiFi to use the WiFiNINA library, which works with the
+ * boards that have the U-Blox NINA chip built in (such as the MKR1010).
+ * It is compatible with 802.11 2.4GHz B/G/N networks.
+ *
+ * If you are using the MKR1010 board, continue on to STEP 2. If you are using WiFiNINA add-on
+ * boards, follow the instructions below.
+ *
+ * To enable for WiFiNINA add-on boards, uncomment the #define WIFI_NINA below.
+ * TBD: Adafruit AirLyft boards are based on the WiFiNINA firmware so may work here.
+ *
+ * IMPORTANT: You must have the WiFI NINA library installed. To easily install this library, open
+ * the library manager via: Arduino IDE Menus: Sketch > Include Library > Manage Libraries > filter
+ * search for "WiFiNINA" > Select the result and click 'install'
+ */
+//#define WIFI_NINA
+
+//do not modify the following 15 lines
+#if defined(ARDUINO_SAMD_MKRWIFI1010) && !defined(WIFI_NINA)
+// automatically include if compiling for MRKWIFI1010
+#define WIFI_NINA
+#endif
+#ifdef WIFI_NINA
+#include <WiFiNINA.h>
+#include "utility/WiFiClientStream.h"
+#include "utility/WiFiServerStream.h"
+  #ifdef WIFI_LIB_INCLUDED
+  #define MULTIPLE_WIFI_LIB_INCLUDES
+  #else
+  #define WIFI_LIB_INCLUDED
+  #endif
+#endif
+
 //------------------------------
 // TODO
 //------------------------------


### PR DESCRIPTION
@dowlingw @eccoscreen 
The board uses the U-Blox WiFi NINA chip which has an ESP32 inside running
NINA firmware. The SAMD21 is connected to the U-Blox chip via SPI. The
WiFININA library is used to communicate between the U-Blox chip and the
SAMD21. Other boards use the same U-Blox chip such as the MKR Vidor 4000
and the Uno WiFi Rev2. Additional changes will be required to support
those boards. See #407 