### PR TITLE
Set Bluefruit LE advertising interval

### DIFF
--- a/examples/StandardFirmataBLE/StandardFirmataBLE.ino
+++ b/examples/StandardFirmataBLE/StandardFirmataBLE.ino
@@ -770,6 +770,10 @@ void setup()
 
   stream.setLocalName(FIRMATA_BLE_LOCAL_NAME);
 
+#ifdef FIRMATA_BLE_ADVERTISING_INTERVAL
+  // set the BLE advertising interval
+  stream.setAdvertisingInterval(FIRMATA_BLE_ADVERTISING_INTERVAL);
+#endif
   // set the BLE connection interval - this is the fastest interval you can read inputs
   stream.setConnectionInterval(FIRMATA_BLE_MIN_INTERVAL, FIRMATA_BLE_MAX_INTERVAL);
   // set how often the BLE TX buffer is flushed (if not full)

--- a/examples/StandardFirmataBLE/bleConfig.h
+++ b/examples/StandardFirmataBLE/bleConfig.h
@@ -74,6 +74,9 @@
 //#define BLUEFRUIT_LE_SPI
 
 #ifdef BLUEFRUIT_LE_SPI
+// Value must be between 20ms and 10.24s
+#define FIRMATA_BLE_ADVERTISING_INTERVAL 20 // 20ms
+
 // Both values must be between 10ms and 4s
 #define FIRMATA_BLE_MIN_INTERVAL 15 // 15ms
 #define FIRMATA_BLE_MAX_INTERVAL 30 // 30ms

--- a/utility/BluefruitLE_SPI_Stream.h
+++ b/utility/BluefruitLE_SPI_Stream.h
@@ -17,6 +17,7 @@ class BluefruitLE_SPI_Stream : public Stream
     BluefruitLE_SPI_Stream(int8_t csPin, int8_t irqPin, int8_t rstPin);
 
     void setLocalName(const char *localName);
+    void setAdvertisingInterval(unsigned short advertisingInterval);
     void setConnectionInterval(unsigned short minConnInterval, unsigned short maxConnInterval);
     void setFlushInterval(int flushInterval);
 
@@ -38,6 +39,7 @@ class BluefruitLE_SPI_Stream : public Stream
     Adafruit_BluefruitLE_SPI ble;
 
     String localName;
+    unsigned short advertisingInterval;
     unsigned short minConnInterval;
     unsigned short maxConnInterval;
 
@@ -48,6 +50,7 @@ class BluefruitLE_SPI_Stream : public Stream
 
 BluefruitLE_SPI_Stream::BluefruitLE_SPI_Stream(int8_t csPin, int8_t irqPin, int8_t rstPin) :
   ble(csPin, irqPin, rstPin),
+  advertisingInterval(0),
   minConnInterval(0),
   maxConnInterval(0),
   txCount(0)
@@ -56,6 +59,11 @@ BluefruitLE_SPI_Stream::BluefruitLE_SPI_Stream(int8_t csPin, int8_t irqPin, int8
 void BluefruitLE_SPI_Stream::setLocalName(const char *localName)
 {
   this->localName = localName;
+}
+
+void BluefruitLE_SPI_Stream::setAdvertisingInterval(unsigned short advertisingInterval)
+{
+  this->advertisingInterval = advertisingInterval;
 }
 
 void BluefruitLE_SPI_Stream::setConnectionInterval(unsigned short minConnInterval, unsigned short maxConnInterval)
@@ -89,14 +97,16 @@ void BluefruitLE_SPI_Stream::begin()
     ble.println(localName);
   }
 
-  // Set connection interval
-  if (minConnInterval > 0 && maxConnInterval > 0) {
-    ble.print("AT+GAPINTERVALS=");
-    ble.print(minConnInterval);
-    ble.print(",");
-    ble.print(maxConnInterval);
-    ble.println(",,,");
-  }
+  // Set connection and advertising intervals
+  ble.print("AT+GAPINTERVALS=");
+  if (minConnInterval > 0) ble.print(minConnInterval);
+  ble.print(",");
+  if (maxConnInterval > 0) ble.print(maxConnInterval);
+  ble.print(",");
+  if (advertisingInterval > 0) ble.print(advertisingInterval);
+  ble.print(",,");  // Always omit fast advertising timeout, hence two commas
+  if (advertisingInterval > 0) ble.print(advertisingInterval);
+  ble.println();
 
   // Disable real and simulated mode switch (i.e. "+++") command
   ble.println("AT+MODESWITCHEN=local,0");


### PR DESCRIPTION
By default, the BLE firmware on the Adafruit Feather M0 Bluefruit LE will switch from fast advertising (20ms interval) to low-power advertising (417.5ms interval) after 30 seconds.  I found that, after the switch to low-power advertising, connection attempts from macOS devices often failed (despite the fact that such a switch is explicitly condoned in [Apple's documentation](https://developer.apple.com/library/archive/qa/qa1931/_index.html)).

These changes alter the default configuration of Bluefruit LE devices to always use the initial, 20ms advertising interval.  They also introduce a new preprocessor macro, `FIRMATA_BLE_ADVERTISING_INTERVAL`, which can be set by other device configurations.  Users who want to stick with the Feather M0's default advertising behavior can simply comment out the macro definition in `bleConfig.h`.