### PR TITLE
Fix build issue with arm none eabi gcc v9.2.1

### DIFF
--- a/Firmata.h
+++ b/Firmata.h
@@ -128,7 +128,7 @@ class FirmataClass
 
     /* private methods ------------------------------ */
     void strobeBlinkPin(byte pin, int count, int onInterval, int offInterval);
-    friend void FirmataMarshaller::encodeByteStream (size_t bytec, uint8_t * bytev, size_t max_bytes = 0) const;
+    friend void FirmataMarshaller::encodeByteStream (size_t bytec, uint8_t * bytev, size_t max_bytes) const;
 
     /* callback functions */
     static callbackFunction currentAnalogCallback;


### PR DESCRIPTION
Firmata/Firmata.h:131:17: error: friend declaration of 'void encodeByteStream(size_t, uint8_t*, size_t) const' specifies default arguments and isn't a definition [-fpermissive]
  131 |     friend void FirmataMarshaller::encodeByteStream (size_t bytec, uint8_t * bytev, size_t max_bytes = 0) const;
      |                 ^~~~~~~~~~~~~~~~~

Ref:
http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2000/n1263.html

Fixes #437