### PR TITLE
Fix compile error for M0 boards

### DIFF
--- a/utility/SerialFirmata.h
+++ b/utility/SerialFirmata.h
@@ -54,7 +54,6 @@
 //    serial buffer/message size and the Firmata frame size (4 bytes) to prevent fragmentation
 //    on the transport layer.
 //#define FIRMATA_SERIAL_RX_DELAY 50 // [ms]
-#define FIRMATA_SERIAL_RX_DELAY 50
 
 #define FIRMATA_SERIAL_FEATURE
 


### PR DESCRIPTION
FIRMATA_SERIAL_RX_DELAY being defined by default resulted [SERIAL_RX_BUFFER_SIZE not being defined](https://github.com/firmata/arduino/blob/e385ece47cfe361f36714fa7f20552058d0229ea/utility/SerialFirmata.cpp#L364) for Arduino M0 boards, resulting in a compile error. Temporary fix is to keep FIRMATA_SERIAL_RX_DELAY commented out by default.
@jnsbyr FYI.