### PR TITLE
fix SERIAL_BUFFER_SIZE for samd

### DIFF
--- a/utility/SerialFirmata.cpp
+++ b/utility/SerialFirmata.cpp
@@ -26,6 +26,10 @@
 #define SERIAL_RX_BUFFER_SIZE UART_TX_FIFO_SIZE
 #endif
 
+#if !defined(SERIAL_RX_BUFFER_SIZE) && defined(SERIAL_BUFFER_SIZE)
+#define SERIAL_RX_BUFFER_SIZE SERIAL_BUFFER_SIZE
+#endif
+
 
 SerialFirmata::SerialFirmata()
 {

--- a/utility/SerialFirmata.cpp
+++ b/utility/SerialFirmata.cpp
@@ -19,16 +19,16 @@
 
 #include "SerialFirmata.h"
 
-// The RX and TX hardware FIFOs of the ESP8266 hold 128 bytes that can be 
-// extended using interrupt handlers. The Arduino constants are not available
-// for the ESP8266 platform.
-#if !defined(SERIAL_RX_BUFFER_SIZE) && defined(UART_TX_FIFO_SIZE)
-#define SERIAL_RX_BUFFER_SIZE UART_TX_FIFO_SIZE
-#endif
-
-// For SAMD and nRF5x core
-#if !defined(SERIAL_RX_BUFFER_SIZE) && defined(SERIAL_BUFFER_SIZE)
-#define SERIAL_RX_BUFFER_SIZE SERIAL_BUFFER_SIZE
+#if !defined(SERIAL_RX_BUFFER_SIZE)
+  #if defined(UART_TX_FIFO_SIZE)
+    // The RX and TX hardware FIFOs of the ESP8266 hold 128 bytes that can be
+    // extended using interrupt handlers. The Arduino constants are not available
+    // for the ESP8266 platform.
+    #define SERIAL_RX_BUFFER_SIZE UART_TX_FIFO_SIZE
+  #elif defined(SERIAL_BUFFER_SIZE)
+    // For SAMD and nRF5x core
+    #define SERIAL_RX_BUFFER_SIZE SERIAL_BUFFER_SIZE
+  #endif
 #endif
 
 

--- a/utility/SerialFirmata.cpp
+++ b/utility/SerialFirmata.cpp
@@ -26,6 +26,7 @@
 #define SERIAL_RX_BUFFER_SIZE UART_TX_FIFO_SIZE
 #endif
 
+// For SAMD and nRF5x core
 #if !defined(SERIAL_RX_BUFFER_SIZE) && defined(SERIAL_BUFFER_SIZE)
 #define SERIAL_RX_BUFFER_SIZE SERIAL_BUFFER_SIZE
 #endif


### PR DESCRIPTION
This PR fixes current master build with SAMD & Adafruit nRF core. PR #448 introduce the usage of  `SERIAL_RX_BUFFER_SIZE` however this symbol is not define on SAMD & nRF core. There is  SERIAL_BUFFER_SIZE that should be used

https://github.com/arduino/ArduinoCore-samd/blob/master/cores/arduino/RingBuffer.h#L31

current build errror

```
SerialFirmata.cpp: In member function 'void SerialFirmata::checkSerial()':
SerialFirmata.cpp:368:56: error: 'SERIAL_RX_BUFFER_SIZE' was not declared in this scope
           if (!((bytesToRead <= 0 && bytesAvailable >= SERIAL_RX_BUFFER_SIZE/2)
                                                        ^~~~~~~~~~~~~~~~~~~~~
/home/hathach/Arduino/libraries/firmata/utility/SerialFirmata.cpp:368:56: note: suggested alternative: 'SERIAL_BUFFER_SIZE'
           if (!((bytesToRead <= 0 && bytesAvailable >= SERIAL_RX_BUFFER_SIZE/2)
                                                        ^~~~~~~~~~~~~~~~~~~~~
                                                        SERIAL_BUFFER_SIZE
Multiple libraries were found for "Firmata.h"
```