### PR TITLE
Import Arduino.h rather than Stream.h

### DIFF
--- a/FirmataMarshaller.h
+++ b/FirmataMarshaller.h
@@ -22,7 +22,7 @@
   #include <stdint.h>
 #endif
 
-#include <Stream.h>
+#include <Arduino.h>
 
 namespace firmata {
 


### PR DESCRIPTION
Per [this note](https://github.com/arduino/ArduinoCore-API/blob/master/api/deprecated/Stream.h#L19) in the Steam.h header file. I'm still trying to understand what led to this change. Apparently Arduino is using a [common core library](https://github.com/arduino/ArduinoCore-API) and if you try to compile against an board from one of the 4 cores referenced in the [readme](https://github.com/arduino/ArduinoCore-API/blob/master/README.md), then you'll get an error regarding Stream.h not being found. Changing to Arduino.h per the note in the Stream.h header seemed to have resolved the issue. Not sure yet if there are other potential issues to be aware of per these changes.