### PR TITLE
Documentation: Add reference to the Firmata Linux Kernel module

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,8 @@ Most of the time you will be interacting with Arduino with a client library on t
   * [https://github.com/NullMember/PDFirmata](https://github.com/NullMember/PDFirmata)
 * Common Lisp
   * [https://github.com/cjfuller/cl-firmata](https://github.com/cjfuller/cl-firmata)
+* Linux Kernel Module
+  * [https://github.com/logicog/firmata_mod]
 
 Note: The above libraries may support various versions of the Firmata protocol and therefore may not support all features of the latest Firmata spec nor all Arduino and Arduino-compatible boards. Refer to the respective projects for details.
 


### PR DESCRIPTION
Adds a reference to the (experimental) Linux Kernel Module firmata_mod, which allows users to use standard Linux userspace APIs/tools to access GPIO, I2C or SPI devices made available on an Arduino attached to a Linux host PC via a serial interface and running the Firmata firmware. In addition, existing Linux Kernel modules for devices using I2C/SPI can also be associated with devices on the Arduino. For example, it is possible to use sensors on the
Arduino board with the standard iio or hwmon Linux drivers. An example would
be an SHT21 humity/heat sensor that can be out-of-the box made accessible e.g
on the KDE desktop without any additional code to be written.