### PR TITLE
Bugfix: UNO R4 WIFI - Now detects proper pwm and adc pin capability.

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -464,8 +464,17 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #define TOTAL_ANALOG_PINS       8
 #define TOTAL_PINS              22 // 14 digital + 8 analog
 #endif
+// These have conflicting(?) definitions in the core for this CPU
+#undef IS_PIN_PWM
+#undef IS_PIN_ANALOG
 #define VERSION_BLINK_PIN       13
 #define IS_PIN_DIGITAL(p)       ((p) >= 2 && (p) <= 19)
+#define IS_PIN_ANALOG(p)        ((p) >= 14 && (p) < 14 + TOTAL_ANALOG_PINS)
+// 25.03.: #define IS_PIN_PWM(p)           digitalPinHasPWM(p)
+#define ARDUINO_IS_PIN_PWM(x)   (((x & PIN_USE_MASK) ==  PIN_PWM_GPT) || ((x & PIN_USE_MASK) ==  PIN_PWM_AGT))
+#define ARDUINO_digitalPinHasPWM(p) (ARDUINO_IS_PIN_PWM(getPinCfgs(p, PIN_CFG_REQ_PWM)[0]))
+#define IS_PIN_PWM(p)           ARDUINO_digitalPinHasPWM(p)
+// END 25.03.
 #define IS_PIN_SERVO(p)         (IS_PIN_DIGITAL(p) && (p) - 2 < MAX_SERVOS)
 #define IS_PIN_I2C(p)           ((p) == 18 || (p) == 19)
 #define IS_PIN_SPI(p)           ((p) == SS || (p) == MOSI || (p) == MISO || (p) == SCK)


### PR DESCRIPTION
Adding fixes per this Arduino Forum post for the UNO R4 Wifi:

https://forum.arduino.cc/t/firmata-via-usb-on-uno-r4-wifi/1383790/11

Fixed bug with pin detection of which pins are pwm and adc capable.   