### PR TITLE
Fix Buffer Overflow Vulnerabilities in Firmata SYSEX Message Processing

### DIFF
--- a/FirmataParser.cpp
+++ b/FirmataParser.cpp
@@ -436,7 +436,8 @@ void FirmataParser::processSysexMessage(void)
         if ( 3 > sysexBytesRead ) {
           (*currentReportFirmwareCallback)(currentReportFirmwareCallbackContext, 0, 0, (const char *)NULL);
         } else {
-          const size_t end_of_string = (string_offset + decodeByteStream((sysexBytesRead - string_offset), &dataBuffer[string_offset]));
+          const size_t bytec = min(sysexBytesRead - string_offset, dataBufferSize - string_offset);
+          const size_t end_of_string = (string_offset + decodeByteStream(bytec, &dataBuffer[string_offset]));
           bufferDataAtPosition('\0', end_of_string); // NULL terminate the string
           (*currentReportFirmwareCallback)(currentReportFirmwareCallbackContext, (size_t)dataBuffer[major_version_offset], (size_t)dataBuffer[minor_version_offset], (const char *)&dataBuffer[string_offset]);
         }
@@ -445,7 +446,8 @@ void FirmataParser::processSysexMessage(void)
     case STRING_DATA:
       if (currentStringCallback) {
         const size_t string_offset = 1;
-        const size_t end_of_string = (string_offset + decodeByteStream((sysexBytesRead - string_offset), &dataBuffer[string_offset]));
+        const size_t bytec = min(sysexBytesRead - string_offset, dataBufferSize - string_offset);
+        const size_t end_of_string = (string_offset + decodeByteStream(bytec, &dataBuffer[string_offset]));
         bufferDataAtPosition('\0', end_of_string); // NULL terminate the string
         (*currentStringCallback)(currentStringCallbackContext, (const char *)&dataBuffer[string_offset]);
       }


### PR DESCRIPTION
### Bug Description
When processing oversized SYSEX messages, buffer overflow occurs due to missing bounds checks in `processSysexMessage()` and `decodeByteStream()`. For example, when `sysexBytesRead = 148` but `dataBufferSize = 64`, the system attempts to process 147 bytes of data in a 64-byte buffer(https://github.com/firmata/arduino/blob/main/FirmataParser.cpp#L448). This causes memory corruption by:

- Writing beyond `dataBuffer` boundaries in `decodeByteStream()`
- Overwriting the `dataBuffer` pointer itself through out-of-bounds writes
- Causing system crashes when the corrupted `dataBuffer` pointer is dereferenced

### Proposed Fix
Ensure `decodeByteStream()` only processes data that actually exists within `dataBuffer` bounds by using `min(sysexBytesRead - offset, dataBufferSize - offset)` in `processSysexMessage` function.